### PR TITLE
feat: rhombus path animation, battle map dedup, bank easter eggs, can…

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -203,8 +203,11 @@ db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS player_banks (
     username TEXT PRIMARY KEY,
     balance REAL DEFAULT 0.00,
-    debt REAL DEFAULT 0.00
+    debt REAL DEFAULT 0.00,
+    first_pay_done INTEGER DEFAULT 0
   )`);
+  // Migrate existing rows that predate the first_pay_done column
+  db.run(`ALTER TABLE player_banks ADD COLUMN first_pay_done INTEGER DEFAULT 0`, () => {});
 
   db.run(`CREATE TABLE IF NOT EXISTS water_bodies (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -32,6 +32,7 @@ module.exports = (db, io, { emitUpdate, recordAction }) => {
     const { key, value } = req.body;
     db.run('INSERT INTO global_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=?', [key, value, value], (err) => {
       if (err) return res.status(500).json({ error: err.message });
+      io.emit('settingsUpdated');
       res.json({ message: 'Settings updated' });
     });
   });

--- a/backend/routes/battle_maps.js
+++ b/backend/routes/battle_maps.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const multer = require('multer');
 const { authenticate } = require('../middleware/auth');
 
@@ -10,15 +11,10 @@ module.exports = (db, io, { emitUpdate }) => {
   const uploadsDir = path.join(__dirname, '../uploads/battle_maps');
   if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
 
-  const storage = multer.diskStorage({
-    destination: (req, file, cb) => cb(null, uploadsDir),
-    filename: (req, file, cb) => {
-      const ext = path.extname(file.originalname);
-      cb(null, Date.now() + '-' + Math.round(Math.random() * 1E9) + ext);
-    }
-  });
-  const upload = multer({ storage });
+  // Memory storage so we can hash before writing to disk.
+  const upload = multer({ storage: multer.memoryStorage() });
 
+  // List maps for a specific location.
   router.get('/', (req, res) => {
     db.all('SELECT * FROM battle_maps WHERE location_id = ? ORDER BY order_index ASC', [req.params.id], (err, rows) => {
       if (err) return res.status(500).json({ error: err.message });
@@ -26,35 +22,20 @@ module.exports = (db, io, { emitUpdate }) => {
     });
   });
 
-  router.post('/', authenticate, upload.single('image'), (req, res) => {
-    if (req.user.isTemporary) {
-      if (req.file) fs.unlinkSync(req.file.path);
-      return res.status(403).json({ error: 'Only main admin can manage battle maps' });
-    }
-
-    const { designation } = req.body;
-    if (!req.file || !designation) {
-      if (req.file) fs.unlinkSync(req.file.path);
-      return res.status(400).json({ error: 'Image and designation are required' });
-    }
-
-    const locationId = req.params.id;
-    const imageUrl = '/uploads/battle_maps/' + req.file.filename;
-
+  // Shared helper: upsert a battle map record.
+  function upsertMap(locationId, designation, imageUrl, res) {
     let orderIndex = 0;
     if (designation === 'Lobby') orderIndex = 0;
     else if (designation === 'Penthouse') orderIndex = 999;
     else if (designation.startsWith('Level ')) {
-      const levelNum = parseInt(designation.split(' ')[1], 10);
-      orderIndex = isNaN(levelNum) ? 1 : levelNum;
+      const n = parseInt(designation.split(' ')[1], 10);
+      orderIndex = isNaN(n) ? 1 : n;
     }
 
-    db.get('SELECT id, image_url FROM battle_maps WHERE location_id = ? AND designation = ?', [locationId, designation], (err, existing) => {
-      if (err) { fs.unlinkSync(req.file.path); return res.status(500).json({ error: err.message }); }
+    db.get('SELECT id FROM battle_maps WHERE location_id = ? AND designation = ?', [locationId, designation], (err, existing) => {
+      if (err) return res.status(500).json({ error: err.message });
 
       if (existing) {
-        const oldPath = path.join(__dirname, '../..', existing.image_url);
-        if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
         db.run('UPDATE battle_maps SET image_url = ?, order_index = ? WHERE id = ?', [imageUrl, orderIndex, existing.id], (err2) => {
           if (err2) return res.status(500).json({ error: err2.message });
           emitUpdate();
@@ -68,23 +49,63 @@ module.exports = (db, io, { emitUpdate }) => {
         });
       }
     });
+  }
+
+  // Upload a new image (deduplicates by content hash).
+  router.post('/', authenticate, upload.single('image'), (req, res) => {
+    if (req.user.isTemporary) return res.status(403).json({ error: 'Only main admin can manage battle maps' });
+
+    const { designation } = req.body;
+    if (!req.file || !designation) return res.status(400).json({ error: 'Image and designation are required' });
+
+    const ext = path.extname(req.file.originalname).toLowerCase();
+    const hash = crypto.createHash('sha256').update(req.file.buffer).digest('hex');
+    const filename = hash + ext;
+    const filepath = path.join(uploadsDir, filename);
+
+    // Only write if this exact file isn't already on disk.
+    if (!fs.existsSync(filepath)) {
+      fs.writeFileSync(filepath, req.file.buffer);
+    }
+
+    const imageUrl = '/uploads/battle_maps/' + filename;
+    upsertMap(req.params.id, designation, imageUrl, res);
+  });
+
+  // Assign an image that is already on the server to this location/designation.
+  router.post('/use-existing', authenticate, express.json(), (req, res) => {
+    if (req.user.isTemporary) return res.status(403).json({ error: 'Only main admin can manage battle maps' });
+
+    const { designation, imageUrl } = req.body;
+    if (!designation || !imageUrl) return res.status(400).json({ error: 'designation and imageUrl are required' });
+
+    // Verify the image actually exists on disk before trusting the URL.
+    const filename = path.basename(imageUrl);
+    const filepath = path.join(uploadsDir, filename);
+    if (!fs.existsSync(filepath)) return res.status(404).json({ error: 'Image not found on server' });
+
+    upsertMap(req.params.id, designation, imageUrl, res);
   });
 
   router.delete('/:mapId', authenticate, (req, res) => {
-    if (req.user.isTemporary) {
-      return res.status(403).json({ error: 'Only main admin can manage battle maps' });
-    }
+    if (req.user.isTemporary) return res.status(403).json({ error: 'Only main admin can manage battle maps' });
+
     db.get('SELECT image_url FROM battle_maps WHERE id = ?', [req.params.mapId], (err, row) => {
       if (err) return res.status(500).json({ error: err.message });
       if (!row) return res.status(404).json({ error: 'Map not found' });
 
-      const filePath = path.join(__dirname, '../..', row.image_url);
-      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+      // Only delete the file if no other battle_map record references it.
+      db.get('SELECT COUNT(*) as cnt FROM battle_maps WHERE image_url = ? AND id != ?', [row.image_url, req.params.mapId], (err2, refRow) => {
+        if (!err2 && refRow && refRow.cnt === 0) {
+          const filePath = path.join(uploadsDir, path.basename(row.image_url));
+          if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+        }
 
-      db.run('DELETE FROM battle_maps WHERE id = ?', [req.params.mapId], (err2) => {
-        if (err2) return res.status(500).json({ error: err2.message });
-        emitUpdate();
-        res.json({ message: 'Battle map deleted' });
+        db.run('DELETE FROM battle_maps WHERE id = ?', [req.params.mapId], (err3) => {
+          if (err3) return res.status(500).json({ error: err3.message });
+          emitUpdate();
+          res.json({ message: 'Battle map deleted' });
+        });
       });
     });
   });

--- a/backend/server.js
+++ b/backend/server.js
@@ -38,6 +38,21 @@ app.use(express.json({ limit: '2mb' }));
 // Routes
 app.use('/api/locations', require('./routes/locations')(db, io, helpers));
 app.use('/api/locations/:id/battle_maps', require('./routes/battle_maps')(db, io, helpers));
+
+// Global battle map image listing (not location-scoped).
+const { authenticate: _auth } = require('./middleware/auth');
+const _bmUploadsDir = require('path').join(__dirname, 'uploads/battle_maps');
+app.get('/api/battle_maps/images', _auth, (req, res) => {
+  const fs = require('fs');
+  try {
+    const files = require('fs').existsSync(_bmUploadsDir)
+      ? fs.readdirSync(_bmUploadsDir).filter(f => /\.(jpg|jpeg|png|gif|webp)$/i.test(f))
+      : [];
+    res.json(files.map(f => ({ filename: f, url: '/uploads/battle_maps/' + f })));
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
 app.use('/api/maps', require('./routes/maps')(db, io, helpers));
 app.use('/api/roads', require('./routes/roads')(db, io, helpers));
 const adminRouter = require('./routes/admin')(db, io, helpers);

--- a/backend/sockets/index.js
+++ b/backend/sockets/index.js
@@ -31,12 +31,12 @@ module.exports = (io, db, { elevatedUsers, emitUpdate, recordAction }) => {
   };
 
   const sendBankUpdate = (username) => {
-    db.get('SELECT balance, debt FROM player_banks WHERE username = ?', [username], (err, row) => {
+    db.get('SELECT balance, debt, first_pay_done FROM player_banks WHERE username = ?', [username], (err, row) => {
       if (!err && row) {
-        io.emit('bankUpdate', { username, balance: row.balance, debt: row.debt });
+        io.emit('bankUpdate', { username, balance: row.balance, debt: row.debt, firstPayDone: !!row.first_pay_done });
       } else if (!err && !row) {
         db.run('INSERT INTO player_banks (username, balance, debt) VALUES (?, 0, 0)', [username], () => {
-          io.emit('bankUpdate', { username, balance: 0, debt: 0 });
+          io.emit('bankUpdate', { username, balance: 0, debt: 0, firstPayDone: false });
         });
       }
     });
@@ -292,6 +292,30 @@ module.exports = (io, db, { elevatedUsers, emitUpdate, recordAction }) => {
       });
     });
 
+    // moveRhombusPath: saves the final position and broadcasts waypoints to
+    // all OTHER clients so they animate along the same path.
+    socket.on('moveRhombusPath', (data) => {
+      const info = userSockets.get(socket.id);
+      if (!info) return;
+      const { id, waypoints } = data; // waypoints: [{x,z}, ...], last entry is the final position
+      if (!Array.isArray(waypoints) || waypoints.length === 0) return;
+      const final = waypoints[waypoints.length - 1];
+      db.get('SELECT owner FROM locations WHERE id = ?', [id], (err, row) => {
+        if (err || !row) return;
+        if (info.isAdmin || info.userName === row.owner) {
+          db.run('UPDATE locations SET x = ?, z = ? WHERE id = ?', [final.x, final.z, id], function(updateErr) {
+            if (!updateErr) {
+              // Broadcast path to everyone else; mover already animated locally.
+              // emitUpdate is intentionally omitted here — it would snap localPos to the
+              // final position on observer clients, killing the path animation mid-flight.
+              // The DB is already correct; late-joiners get the right position on initial load.
+              socket.broadcast.emit('rhombusPath', { id, waypoints });
+            }
+          });
+        }
+      });
+    });
+
     socket.on('battle_map_enter', (data) => {
       const info = userSockets.get(socket.id);
       if (info) { info.currentBattleMapId = data.locationId; info.currentFloorIndex = data.floorIndex; broadcastActiveUsers(); }
@@ -443,6 +467,11 @@ module.exports = (io, db, { elevatedUsers, emitUpdate, recordAction }) => {
     // --- Banking ---
     socket.on('requestBankBalance', (data) => {
       if (data && data.username) sendBankUpdate(data.username);
+    });
+
+    socket.on('markFirstPayDone', (data) => {
+      if (!data || !data.username) return;
+      db.run('UPDATE player_banks SET first_pay_done = 1 WHERE username = ?', [data.username]);
     });
 
     socket.on('withdrawFunds', (data) => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -28,15 +31,75 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "jsdom": "^29.1.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.59.2",
-        "vite": "^8.0.12"
+        "vite": "^8.0.12",
+        "vitest": "^4.1.9"
       }
     },
     "..": {
       "name": "mapsystem",
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -287,6 +350,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
@@ -453,6 +669,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -976,6 +1210,103 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -992,6 +1323,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/draco3d": {
       "version": "1.4.10",
@@ -1377,6 +1734,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1415,6 +1885,51 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -1574,6 +2089,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1613,11 +2138,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1636,12 +2196,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-gpu": {
       "version": "5.0.70",
@@ -1661,6 +2238,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -1696,6 +2281,26 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1895,6 +2500,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1903,6 +2518,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2081,6 +2706,19 @@
       "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
       "license": "Apache-2.0"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2127,6 +2765,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2149,6 +2797,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
@@ -2180,6 +2835,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2548,6 +3254,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/maath": {
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
@@ -2558,9 +3275,26 @@
         "three": ">=0.134.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/mapsystem": {
       "resolved": "..",
       "link": true
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/meshline": {
       "version": "3.3.1",
@@ -2576,6 +3310,16 @@
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
       "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "license": "MIT"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -2635,6 +3379,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2685,6 +3443,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2703,6 +3474,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2769,6 +3547,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
@@ -2810,6 +3604,14 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-use-measure": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
@@ -2823,6 +3625,20 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-from-string": {
@@ -2868,6 +3684,19 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2904,6 +3733,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
@@ -2943,6 +3779,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stats-gl": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
@@ -2969,6 +3812,26 @@
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/suspend-react": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
@@ -2977,6 +3840,13 @@
       "peerDependencies": {
         "react": ">=17.0"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/three": {
       "version": "0.184.0",
@@ -3016,6 +3886,23 @@
       "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3031,6 +3918,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/troika-three-text": {
@@ -3170,6 +4113,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3316,6 +4269,109 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webgl-constants": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
@@ -3326,6 +4382,41 @@
       "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -3340,6 +4431,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -3372,6 +4480,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -391,6 +391,7 @@ header {
   background: #330000 !important;
   border-color: #ff0000 !important;
   color: #ff0000 !important;
+  text-shadow: 1px 1px 2px #000, 2px 2px 4px #000 !important;
 }
 
 .danger-btn:hover {
@@ -650,6 +651,7 @@ header {
 }
 
 .win95-content {
+  position: relative;
   padding: 15px;
   color: var(--green);
   font-size: 0.8rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { Canvas, useThree, useFrame } from '@react-three/fiber';
 import { OrbitControls, CameraControls, PerspectiveCamera, Grid, TransformControls, Bvh, Html, OrthographicCamera } from '@react-three/drei';
@@ -133,7 +133,7 @@ function App() {
   const [isChatOpen, setIsChatOpen] = useState(false);
   const [hasUnreadChat, setHasUnreadChat] = useState(false);
   const [isBankOpen, setIsBankOpen] = useState(false);
-  const [bankData, setBankData] = useState<{ balance: number, debt: number }>({ balance: 0, debt: 0 });
+  const [bankData, setBankData] = useState<{ balance: number, debt: number, firstPayDone?: boolean }>({ balance: 0, debt: 0 });
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
 
   // Load notification preference from the user's rhombus data
@@ -217,12 +217,18 @@ function App() {
 
   const toggleSelection = (id: number) => { setSelectedIds(prev => prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id]); };
 
-  useEffect(() => {
+  const fetchCurrentLocBattleMaps = useCallback(() => {
     if (selectedLocation && selectedLocation.shape !== 'rhombus' && selectedLocation.shape !== 'enemy_rhombus') {
       fetch(`/api/locations/${selectedLocation.id}/battle_maps`)
         .then(res => res.json())
         .then(data => setCurrentLocBattleMaps(Array.isArray(data) ? data : []))
         .catch(() => setCurrentLocBattleMaps([]));
+    }
+  }, [selectedLocation?.id]);
+
+  useEffect(() => {
+    if (selectedLocation && selectedLocation.shape !== 'rhombus' && selectedLocation.shape !== 'enemy_rhombus') {
+      fetchCurrentLocBattleMaps();
     } else {
       setCurrentLocBattleMaps([]);
     }
@@ -469,11 +475,14 @@ function App() {
     userName, token, isLoggedIn,
     notificationsEnabled, isChatOpen,
     onFetchAll: fetchAll,
+    onFetchGlobalSettings: fetchGlobalSettings,
     onFetchLocations: fetchLocations,
     onFetchRoads: fetchRoads,
     onFetchDistricts: fetchDistricts,
     onFetchWaterBodies: fetchWaterBodies,
-    onBankUpdate: (balance, debt) => setBankData({ balance, debt }),
+    onFetchBattleMaps: fetchCurrentLocBattleMaps,
+    onBankUpdate: (balance, debt, firstPayDone) => setBankData({ balance, debt, firstPayDone }),
+    onBalancePaid: (balance, debt, firstPayDone) => { setBankData({ balance, debt, firstPayDone }); setIsBankOpen(true); },
     onNotification: setNotification,
     onHasUnreadChat: setHasUnreadChat,
     onTokenUpdate: setToken,
@@ -740,7 +749,7 @@ function App() {
     
     // 2. Wait for animation to finish before unmounting map
     setTimeout(() => {
-        if (socket) socket.disconnect();
+        if (socketRef.current) socketRef.current.disconnect();
         setToken('');
         setIsAdmin(false);
         setIsLoggedIn(false);
@@ -791,7 +800,7 @@ function App() {
         <>
           <div className="ui-overlay">
       {showBattleMapManager && (selectedLocation || activeEditLocation || editId) && (
-        <BattleMapManager locationId={selectedLocation ? selectedLocation.id : (activeEditLocation ? activeEditLocation.id : editId)} token={token} onClose={() => setShowBattleMapManager(false)} />
+        <BattleMapManager locationId={selectedLocation ? selectedLocation.id : (activeEditLocation ? activeEditLocation.id : editId)} token={token} onClose={() => setShowBattleMapManager(false)} onMapsChanged={fetchCurrentLocBattleMaps} />
       )}
       {view === 'battle_map' && activeBattleMapData && (
         <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, pointerEvents: 'none', zIndex: 2000 }}>
@@ -985,17 +994,24 @@ function App() {
                   activeUsers={activeUsers}
               />
             )}
-            {isBankOpen && (
-              <BankWindow 
-                  pos={bankPos} 
-                  setPos={setBankPos} 
-                  onClose={() => setIsBankOpen(false)} 
-                  bankData={bankData} 
-                  socket={socketRef.current} 
-                  userName={userName} 
-                  isBankOpen={isBankOpen}
-              />
-            )}
+            <BankWindow
+                pos={bankPos}
+                setPos={setBankPos}
+                onClose={() => setIsBankOpen(false)}
+                bankData={bankData}
+                socket={socketRef.current}
+                userName={userName}
+                isBankOpen={isBankOpen}
+                firstPayDone={bankData.firstPayDone}
+                audioEnabled={audioEnabled}
+                soundVolumes={{
+                  cashregister: parseFloat(globalSettings?.bank_vol_cashregister ?? '1'),
+                  debtpaid: parseFloat(globalSettings?.bank_vol_debtpaid ?? '1'),
+                  highroller: parseFloat(globalSettings?.bank_vol_highroller ?? '1'),
+                  firstpay: parseFloat(globalSettings?.bank_vol_firstpay ?? '1'),
+                  overdraft: parseFloat(globalSettings?.bank_vol_overdraft ?? '1'),
+                }}
+            />
               <ChatWindow 
                   pos={chatPos} 
                   setPos={setChatPos} 

--- a/frontend/src/BattleMapManager.tsx
+++ b/frontend/src/BattleMapManager.tsx
@@ -1,131 +1,214 @@
 import React, { useState, useEffect } from 'react';
 
-export const BattleMapManager = ({ locationId, onClose, token }: { locationId: number, onClose: () => void, token: string }) => {
+interface ConfirmModal { message: string; onConfirm: () => void; }
+
+export const BattleMapManager = ({ locationId, onClose, token, onMapsChanged }: { locationId: number; onClose: () => void; token: string; onMapsChanged?: () => void }) => {
   const [maps, setMaps] = useState<any[]>([]);
+  const [tab, setTab] = useState<'upload' | 'existing'>('upload');
+  const [allImages, setAllImages] = useState<{ filename: string; url: string }[]>([]);
   const [designationType, setDesignationType] = useState('Level');
   const [levelNumber, setLevelNumber] = useState(1);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedExistingUrl, setSelectedExistingUrl] = useState<string | null>(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [confirmModal, setConfirmModal] = useState<ConfirmModal | null>(null);
+
+  useEffect(() => { fetchMaps(); }, [locationId]);
 
   useEffect(() => {
-    fetchMaps();
-  }, [locationId]);
+    if (tab === 'existing' && allImages.length === 0) fetchAllImages();
+  }, [tab]);
 
   const fetchMaps = async () => {
     try {
       const res = await fetch(`/api/locations/${locationId}/battle_maps`);
-      if (res.ok) {
-        const data = await res.json();
-        setMaps(data);
-      }
-    } catch (err) {
-      console.error(err);
+      if (res.ok) setMaps(await res.json());
+    } catch (err) { console.error(err); }
+  };
+
+  const fetchAllImages = async () => {
+    try {
+      const res = await fetch('/api/battle_maps/images', { headers: { Authorization: `Bearer ${token}` } });
+      if (res.ok) setAllImages(await res.json());
+    } catch (err) { console.error(err); }
+  };
+
+  const getDesignation = () => designationType === 'Level' ? `Level ${levelNumber}` : designationType;
+
+  const checkOverride = (designation: string, proceed: () => void) => {
+    if (maps.some(m => m.designation === designation)) {
+      setConfirmModal({ message: `A map for ${designation} already exists. Replace it?`, onConfirm: proceed });
+    } else {
+      proceed();
     }
   };
 
-  const handleUpload = async () => {
+  const doUpload = async () => {
     if (!selectedFile) return setError('Select an image file');
-    
-    let designation = designationType;
-    if (designationType === 'Level') designation = `Level ${levelNumber}`;
-
-    // Check for override
-    if (maps.some(m => m.designation === designation)) {
-      if (!window.confirm(`A map for ${designation} already exists. Replace it?`)) return;
-    }
-
-    setLoading(true);
-    setError('');
-
+    setLoading(true); setError('');
     const formData = new FormData();
     formData.append('image', selectedFile);
-    formData.append('designation', designation);
-
+    formData.append('designation', getDesignation());
     try {
       const res = await fetch(`/api/locations/${locationId}/battle_maps`, {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}` },
-        body: formData
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
       });
-
-      if (res.ok) {
-        setSelectedFile(null);
-        fetchMaps();
-      } else {
-        const data = await res.json();
-        setError(data.error || 'Upload failed');
-      }
-    } catch (err: any) {
-      setError(err.message);
-    }
+      if (res.ok) { setSelectedFile(null); fetchMaps(); onMapsChanged?.(); }
+      else { const d = await res.json(); setError(d.error || 'Upload failed'); }
+    } catch (err: any) { setError(err.message); }
     setLoading(false);
   };
 
-  const handleDelete = async (mapId: number) => {
-    if (!window.confirm('Delete this map?')) return;
+  const handleUpload = () => checkOverride(getDesignation(), doUpload);
+
+  const doUseExisting = async (designation: string) => {
+    if (!selectedExistingUrl) return;
+    setLoading(true); setError('');
+    try {
+      const res = await fetch(`/api/locations/${locationId}/battle_maps/use-existing`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ designation, imageUrl: selectedExistingUrl }),
+      });
+      if (res.ok) { setSelectedExistingUrl(null); fetchMaps(); onMapsChanged?.(); setTab('upload'); }
+      else { const d = await res.json(); setError(d.error || 'Failed'); }
+    } catch (err: any) { setError(err.message); }
+    setLoading(false);
+  };
+
+  const handleUseExisting = () => {
+    if (!selectedExistingUrl) return setError('Select an image first');
+    checkOverride(getDesignation(), () => doUseExisting(getDesignation()));
+  };
+
+  const doDelete = async (mapId: number) => {
     try {
       const res = await fetch(`/api/locations/${locationId}/battle_maps/${mapId}`, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${token}` }
+        headers: { Authorization: `Bearer ${token}` },
       });
-      if (res.ok) fetchMaps();
-    } catch (err) {
-      console.error(err);
-    }
+      if (res.ok) { fetchMaps(); onMapsChanged?.(); }
+    } catch (err) { console.error(err); }
   };
 
+  const handleDelete = (mapId: number, designation: string) =>
+    setConfirmModal({ message: `Delete map for ${designation}?`, onConfirm: () => doDelete(mapId) });
+
+  const tabBtn = (id: 'upload' | 'existing', label: string) => (
+    <button
+      type="button"
+      onClick={() => setTab(id)}
+      style={{
+        flex: 1, padding: '6px', background: tab === id ? '#00ff00' : '#111',
+        color: tab === id ? '#000' : '#00ff00', border: '1px solid #00ff00',
+        fontFamily: 'monospace', cursor: 'pointer', fontWeight: 'bold',
+      }}
+    >{label}</button>
+  );
+
+  const designationControls = (
+    <div style={{ display: 'flex', gap: '8px', marginBottom: '10px', alignItems: 'center' }}>
+      {['Lobby', 'Level', 'Penthouse'].map(opt => (
+        <button key={opt} type="button" className="utility-btn" onClick={() => setDesignationType(opt)} style={{
+          margin: 0,
+          backgroundColor: designationType === opt ? '#00ff00' : '#111',
+          color: designationType === opt ? '#000' : '#00ff00',
+          border: `1px solid ${designationType === opt ? '#00ff00' : '#333'}`,
+        }}>{opt.toUpperCase()}</button>
+      ))}
+      {designationType === 'Level' && (
+        <input type="number" min="1" value={levelNumber} onChange={(e) => setLevelNumber(parseInt(e.target.value) || 1)}
+          style={{ width: '50px', backgroundColor: '#000', border: '1px solid #00ff00', color: '#00ff00', padding: '4px' }} />
+      )}
+    </div>
+  );
+
   return (
-    <div className="panel" style={{
-      position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
-      backgroundColor: '#111', padding: '20px', border: '1px solid #00ff00', zIndex: 10000, color: '#00ff00', pointerEvents: 'auto'
-    }}>
-      <h3>BATTLE MAPS MANAGEMENT</h3>
-      <button style={{ position: 'absolute', top: '10px', right: '10px' }} onClick={onClose}>X</button>
-      
-      <div style={{ marginBottom: '20px', borderBottom: '1px solid #333', paddingBottom: '10px' }}>
-        <h4>UPLOAD NEW MAP</h4>
-        <input type="file" accept="image/*" onChange={(e) => setSelectedFile(e.target.files?.[0] || null)} style={{ display: 'block', marginBottom: '10px' }} />
-        
-        <div style={{ display: 'flex', gap: '10px', marginBottom: '10px', alignItems: 'center' }}>
-          {['Lobby', 'Level', 'Penthouse'].map(opt => (
-            <button 
-              key={opt}
-              type="button"
-              className="utility-btn"
-              onClick={() => setDesignationType(opt)}
-              style={{ 
-                margin: 0,
-                backgroundColor: designationType === opt ? '#00ff00' : '#111', 
-                color: designationType === opt ? '#000' : '#00ff00',
-                border: designationType === opt ? '1px solid #00ff00' : '1px solid #333'
-              }}
-            >
-              {opt.toUpperCase()}
-            </button>
-          ))}
-          {designationType === 'Level' && (
-            <input type="number" min="1" value={levelNumber} onChange={(e) => setLevelNumber(parseInt(e.target.value) || 1)} style={{ width: '50px', backgroundColor: '#000', border: '1px solid #00ff00', color: '#00ff00', padding: '4px', height: '100%' }} />
-          )}
+    <>
+      {confirmModal && (
+        <div style={{
+          position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)', zIndex: 20000,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <div style={{ background: '#111', border: '1px solid #ff0000', padding: '24px', color: '#00ff00', fontFamily: 'monospace', maxWidth: '360px', width: '90%' }}>
+            <p style={{ marginTop: 0 }}>{confirmModal.message}</p>
+            <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+              <button className="utility-btn" onClick={() => setConfirmModal(null)}>CANCEL</button>
+              <button className="upload-btn danger-btn" onClick={() => { confirmModal.onConfirm(); setConfirmModal(null); }}>CONFIRM</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="panel" style={{
+        position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+        backgroundColor: '#111', padding: '20px', border: '1px solid #00ff00',
+        zIndex: 10000, color: '#00ff00', pointerEvents: 'auto', width: '480px', maxWidth: '95vw',
+      }}>
+        <h3 style={{ margin: '0 0 12px' }}>BATTLE MAPS MANAGEMENT</h3>
+        <button style={{ position: 'absolute', top: '10px', right: '10px' }} onClick={onClose}>X</button>
+
+        <div style={{ display: 'flex', marginBottom: '16px' }}>
+          {tabBtn('upload', 'UPLOAD NEW')}
+          {tabBtn('existing', 'SELECT EXISTING')}
         </div>
 
-        <button className="upload-btn" onClick={handleUpload} disabled={loading}>{loading ? 'UPLOADING...' : 'UPLOAD MAP'}</button>
-        {error && <p style={{ color: 'red' }}>{error}</p>}
-      </div>
-
-      <div>
-        <h4>EXISTING MAPS</h4>
-        {maps.length === 0 ? <p>No maps uploaded yet.</p> : (
-          <ul style={{ listStyle: 'none', padding: 0 }}>
-            {maps.map(m => (
-              <li key={m.id} style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', padding: '5px', backgroundColor: '#222' }}>
-                <span>[{m.designation}]</span>
-                <button className="upload-btn danger-btn" onClick={() => handleDelete(m.id)}>DELETE</button>
-              </li>
-            ))}
-          </ul>
+        {tab === 'upload' && (
+          <div style={{ marginBottom: '16px', borderBottom: '1px solid #333', paddingBottom: '16px' }}>
+            <input type="file" accept="image/*" onChange={(e) => setSelectedFile(e.target.files?.[0] || null)}
+              style={{ display: 'block', marginBottom: '10px', color: '#00ff00' }} />
+            {designationControls}
+            <button className="upload-btn" onClick={handleUpload} disabled={loading}>
+              {loading ? 'UPLOADING...' : 'UPLOAD MAP'}
+            </button>
+          </div>
         )}
+
+        {tab === 'existing' && (
+          <div style={{ marginBottom: '16px', borderBottom: '1px solid #333', paddingBottom: '16px' }}>
+            {allImages.length === 0 ? (
+              <p style={{ color: '#666' }}>No images on server yet.</p>
+            ) : (
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px', maxHeight: '260px', overflowY: 'auto', marginBottom: '12px' }}>
+                {allImages.map(img => (
+                  <div key={img.filename} onClick={() => setSelectedExistingUrl(img.url)} style={{
+                    cursor: 'pointer', border: `2px solid ${selectedExistingUrl === img.url ? '#00ff00' : '#333'}`,
+                    padding: '2px', background: selectedExistingUrl === img.url ? '#001a00' : '#000',
+                  }}>
+                    <img src={img.url} alt={img.filename} style={{ width: '100%', aspectRatio: '1', objectFit: 'cover', display: 'block' }} />
+                    <div style={{ fontSize: '9px', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', padding: '2px' }}>
+                      {img.filename.slice(0, 16)}…
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+            {designationControls}
+            <button className="upload-btn" onClick={handleUseExisting} disabled={loading || !selectedExistingUrl}>
+              {loading ? 'SAVING...' : 'USE THIS IMAGE'}
+            </button>
+          </div>
+        )}
+
+        {error && <p style={{ color: 'red', margin: '8px 0' }}>{error}</p>}
+
+        <div>
+          <h4 style={{ margin: '0 0 8px' }}>CURRENT MAPS FOR THIS LOCATION</h4>
+          {maps.length === 0 ? <p style={{ color: '#666' }}>No maps uploaded yet.</p> : (
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {maps.map(m => (
+                <li key={m.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '5px', padding: '5px', backgroundColor: '#222' }}>
+                  <span>[{m.designation}]</span>
+                  <button className="upload-btn danger-btn" onClick={() => handleDelete(m.id, m.designation)}>DELETE</button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -3,6 +3,8 @@ import { createPortal } from 'react-dom';
 import * as THREE from 'three';
 import { isUserDefinedName, getStructLabel } from '../utils/locationHelpers';
 import { generateThemedBuildingsForPlot } from './Buildings';
+import type { BankSoundKey } from './BankWindows';
+import { playCashRegister, playWompWomp, playCalibration, playProudFanfare, playHighRollerSound } from './BankWindows';
 
 export function AdminPanel({
   socketRef, token, onLogout, refreshLocations, refreshRoads, locations, roads, editData, setEditData, editId, setEditId,
@@ -478,7 +480,7 @@ export function AdminPanel({
   const resolvedDeleteTarget = deleteTarget?.parent_id ? locations.find((l: any) => l.id === deleteTarget.parent_id) || deleteTarget : deleteTarget;
 
   return (
-    <div className="panel admin-panel">
+    <div className="panel admin-panel" style={{ maxHeight: '90vh', overflowY: 'auto' }}>
       {adminAlert && createPortal(
         <div className="modal-overlay" style={{ zIndex: 10000 }}>
           <div className="panel critical-alert">
@@ -568,6 +570,12 @@ export function AdminPanel({
                   }}>APPLY</button>
               </div>
           </div>
+
+          <button onClick={() => setIsAdminPayOpen(true)} className="utility-btn" style={{ width: '100%', marginTop: '10px' }}>PAY_PLAYERS</button>
+
+          {/* BANK SOUNDS TEST PANEL */}
+          <BankSoundsPanel token={token} globalSettings={globalSettings} fetchGlobalSettings={fetchGlobalSettings} />
+
           <button className="utility-btn danger-btn" style={{marginTop: '10px', width: '100%'}} onClick={async () => {
             if (confirm("PURGE ALL ROAD DATA?")) {
               const res = await fetch('/api/roads', { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } });
@@ -640,7 +648,6 @@ export function AdminPanel({
               <div key={loc.id} className={`list-item ${selectedLocation?.id === loc.id ? 'selected' : ''}`} onClick={() => setSelectedLocation(loc)} style={{cursor: 'pointer', paddingLeft: '20px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px'}}><div style={{display: 'flex', alignItems: 'center', gap: '10px', flex: 1, overflow: 'hidden'}}><input type="checkbox" checked={selectedIds.includes(loc.id)} onChange={() => toggleSelection(loc.id)} onClick={(e) => e.stopPropagation()} /><span style={{overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}>{getStructLabel(loc)}</span></div>{!isBatchSelecting && <div style={{display: 'flex', gap: '5px'}}><button className="upload-btn" style={{padding: '2px 5px', fontSize: '0.6rem', width: 'auto'}} onClick={(e) => { e.stopPropagation(); startEdit(loc); }}>EDIT</button><button className="upload-btn danger-btn" style={{padding: '2px 5px', fontSize: '0.6rem', width: 'auto'}} onClick={(e) => { e.stopPropagation(); setDeleteTarget(loc); }}>DEL</button></div>}</div>
             ))}
           </div>
-          <button onClick={() => setIsAdminPayOpen(true)} className="upload-btn" style={{ width: '100%', marginBottom: '10px', backgroundColor: '#00ff66', color: '#000' }}>PAY_PLAYERS</button>
           <button onClick={onLogout} className="logout-btn">EXIT_ADMIN_MODE</button>
         </>
       )}
@@ -1382,6 +1389,93 @@ export function AdminPanel({
             )}
           </form>
         </>
+      )}
+    </div>
+  );
+}
+
+const BANK_SOUND_KEYS: BankSoundKey[] = ['cashregister', 'debtpaid', 'highroller', 'firstpay', 'overdraft'];
+const BANK_SOUND_LABELS: Record<BankSoundKey, string> = {
+  cashregister: 'Cash Register',
+  debtpaid: 'Debt Paid Off',
+  highroller: 'High Roller 🐋',
+  firstpay: 'First Payday 🎊',
+  overdraft: 'Overdraft 😢',
+};
+const BANK_SOUND_TESTERS: Record<BankSoundKey, (vol: number) => void> = {
+  cashregister: playCashRegister,
+  debtpaid: playProudFanfare,
+  highroller: playHighRollerSound,
+  firstpay: playCalibration,
+  overdraft: playWompWomp,
+};
+
+function BankSoundsPanel({ token, globalSettings, fetchGlobalSettings }: { token: string; globalSettings: any; fetchGlobalSettings: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [volumes, setVolumes] = useState<Record<BankSoundKey, number>>({
+    cashregister: 1, debtpaid: 1, highroller: 1, firstpay: 1, overdraft: 1,
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!globalSettings) return;
+    setVolumes({
+      cashregister: parseFloat(globalSettings.bank_vol_cashregister ?? '1'),
+      debtpaid: parseFloat(globalSettings.bank_vol_debtpaid ?? '1'),
+      highroller: parseFloat(globalSettings.bank_vol_highroller ?? '1'),
+      firstpay: parseFloat(globalSettings.bank_vol_firstpay ?? '1'),
+      overdraft: parseFloat(globalSettings.bank_vol_overdraft ?? '1'),
+    });
+  }, [globalSettings]);
+
+  const saveVolumes = async () => {
+    setSaving(true);
+    await Promise.all(BANK_SOUND_KEYS.map(key =>
+      fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ key: `bank_vol_${key}`, value: volumes[key] }),
+      })
+    ));
+    setSaving(false);
+    fetchGlobalSettings();
+  };
+
+  return (
+    <div style={{ marginTop: '10px', borderTop: '1px solid #00ff00', paddingTop: '10px' }}>
+      <button
+        className="utility-btn"
+        style={{ width: '100%', textAlign: 'left', display: 'flex', justifyContent: 'space-between' }}
+        onClick={() => setOpen(o => !o)}
+      >
+        <span>BANK SOUNDS</span>
+        <span>{open ? '▲' : '▼'}</span>
+      </button>
+      {open && (
+        <div style={{ marginTop: '8px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          {BANK_SOUND_KEYS.map(key => (
+            <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <button
+                className="utility-btn"
+                style={{ minWidth: '36px', padding: '4px 8px' }}
+                onClick={() => BANK_SOUND_TESTERS[key](volumes[key])}
+              >▶</button>
+              <span style={{ minWidth: '130px', fontSize: '0.75rem' }}>{BANK_SOUND_LABELS[key]}</span>
+              <input
+                type="range" min="0" max="2" step="0.05"
+                value={volumes[key]}
+                onChange={e => setVolumes(v => ({ ...v, [key]: parseFloat(e.target.value) }))}
+                style={{ flex: 1 }}
+              />
+              <span style={{ minWidth: '32px', fontSize: '0.75rem', textAlign: 'right' }}>
+                {Math.round(volumes[key] * 100)}%
+              </span>
+            </div>
+          ))}
+          <button className="utility-btn" onClick={saveVolumes} disabled={saving} style={{ marginTop: '4px' }}>
+            {saving ? 'SAVING...' : 'SAVE VOLUMES'}
+          </button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/BankWindows.tsx
+++ b/frontend/src/components/BankWindows.tsx
@@ -1,6 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { DraggableWindow } from './DraggableWindow';
 import creditsPngIcon from '../assets/Credits.png';
+
+export type BankSoundKey = 'cashregister' | 'debtpaid' | 'highroller' | 'firstpay' | 'overdraft';
+export type BankSoundVolumes = Record<BankSoundKey, number>;
 
 export const formatBankValue = (val: number) => {
   const rounded = Math.round(val * 100) / 100;
@@ -124,6 +127,205 @@ export function AdminPayWindow({ pos, setPos, onClose, socket, token, activeUser
   );
 }
 
+export function playCashRegister(vol = 1) {
+  try {
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const master = ctx.createGain(); master.gain.value = vol; master.connect(ctx.destination);
+
+    const click = ctx.createOscillator(); const clickGain = ctx.createGain();
+    click.connect(clickGain); clickGain.connect(master);
+    click.frequency.setValueAtTime(1400, ctx.currentTime);
+    click.frequency.exponentialRampToValueAtTime(220, ctx.currentTime + 0.06);
+    clickGain.gain.setValueAtTime(0.26, ctx.currentTime);
+    clickGain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.09);
+    click.start(ctx.currentTime); click.stop(ctx.currentTime + 0.09);
+
+    const bell = ctx.createOscillator(); const bellGain = ctx.createGain();
+    bell.type = 'sine'; bell.connect(bellGain); bellGain.connect(master);
+    bell.frequency.setValueAtTime(2200, ctx.currentTime + 0.07);
+    bellGain.gain.setValueAtTime(0.001, ctx.currentTime + 0.07);
+    bellGain.gain.linearRampToValueAtTime(0.34, ctx.currentTime + 0.09);
+    bellGain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.9);
+    bell.start(ctx.currentTime + 0.07); bell.stop(ctx.currentTime + 0.9);
+
+    const bell2 = ctx.createOscillator(); const bell2Gain = ctx.createGain();
+    bell2.type = 'sine'; bell2.connect(bell2Gain); bell2Gain.connect(master);
+    bell2.frequency.setValueAtTime(3520, ctx.currentTime + 0.07);
+    bell2Gain.gain.setValueAtTime(0.001, ctx.currentTime + 0.07);
+    bell2Gain.gain.linearRampToValueAtTime(0.165, ctx.currentTime + 0.09);
+    bell2Gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.55);
+    bell2.start(ctx.currentTime + 0.07); bell2.stop(ctx.currentTime + 0.55);
+
+    setTimeout(() => ctx.close(), 1100);
+  } catch (_) {}
+}
+
+export function playWompWomp(vol = 1) {
+  try {
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const master = ctx.createGain(); master.gain.value = vol; master.connect(ctx.destination);
+    const filter = ctx.createBiquadFilter();
+    filter.type = 'lowpass'; filter.frequency.value = 420; filter.Q.value = 0.8;
+    filter.connect(master);
+
+    const womp = (t: number, from: number, to: number, dur: number) => {
+      const osc = ctx.createOscillator(); const gain = ctx.createGain();
+      osc.type = 'sawtooth'; osc.connect(gain); gain.connect(filter);
+      osc.frequency.setValueAtTime(from, t);
+      osc.frequency.exponentialRampToValueAtTime(to, t + dur);
+      gain.gain.setValueAtTime(0.001, t);
+      gain.gain.linearRampToValueAtTime(0.28, t + 0.06);
+      gain.gain.setValueAtTime(0.28, t + dur - 0.1);
+      gain.gain.exponentialRampToValueAtTime(0.001, t + dur);
+      osc.start(t); osc.stop(t + dur);
+    };
+    womp(ctx.currentTime,        220, 110, 0.45);
+    womp(ctx.currentTime + 0.52, 175,  85, 0.56);
+    setTimeout(() => ctx.close(), 1300);
+  } catch (_) {}
+}
+
+// Calibration tone sequence — sterile, precise beeps ascending in pitch
+export function playCalibration(vol = 1) {
+  try {
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const master = ctx.createGain(); master.gain.value = vol; master.connect(ctx.destination);
+    const freqs = [440, 550, 660, 880];
+    freqs.forEach((hz, i) => {
+      const osc = ctx.createOscillator(); const gain = ctx.createGain();
+      osc.type = 'sine'; osc.frequency.value = hz;
+      osc.connect(gain); gain.connect(master);
+      const t = ctx.currentTime + i * 0.18;
+      gain.gain.setValueAtTime(0.001, t);
+      gain.gain.linearRampToValueAtTime(0.3, t + 0.02);
+      gain.gain.setValueAtTime(0.3, t + 0.10);
+      gain.gain.exponentialRampToValueAtTime(0.001, t + 0.16);
+      osc.start(t); osc.stop(t + 0.16);
+    });
+    setTimeout(() => ctx.close(), 1200);
+  } catch (_) {}
+}
+
+// Proud fanfare — triumphant ascending brass-like chord resolve
+export function playProudFanfare(vol = 1) {
+  try {
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const master = ctx.createGain(); master.gain.value = vol; master.connect(ctx.destination);
+
+    const note = (hz: number, t: number, dur: number, peak = 0.25) => {
+      const osc = ctx.createOscillator(); const gain = ctx.createGain();
+      osc.type = 'triangle'; osc.frequency.value = hz;
+      osc.connect(gain); gain.connect(master);
+      gain.gain.setValueAtTime(0.001, t);
+      gain.gain.linearRampToValueAtTime(peak, t + 0.04);
+      gain.gain.setValueAtTime(peak, t + dur - 0.08);
+      gain.gain.exponentialRampToValueAtTime(0.001, t + dur);
+      osc.start(t); osc.stop(t + dur);
+    };
+
+    // Rising motif: G A B — then triumphant C major chord held
+    const T = ctx.currentTime;
+    note(392, T,        0.18);          // G4
+    note(440, T + 0.20, 0.18);          // A4
+    note(494, T + 0.40, 0.18);          // B4
+    note(523, T + 0.62, 0.70);          // C5 \
+    note(659, T + 0.62, 0.70, 0.20);   // E5  > major chord
+    note(784, T + 0.62, 0.70, 0.15);   // G5 /
+
+    setTimeout(() => ctx.close(), 1600);
+  } catch (_) {}
+}
+
+// High Roller jackpot — dramatic casino ascending arpeggio + big hit
+export function playHighRollerSound(vol = 1) {
+  try {
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const master = ctx.createGain(); master.gain.value = vol; master.connect(ctx.destination);
+
+    const note = (hz: number, t: number, dur: number, peak = 0.22, type: OscillatorType = 'sine') => {
+      const osc = ctx.createOscillator(); const gain = ctx.createGain();
+      osc.type = type; osc.frequency.value = hz;
+      osc.connect(gain); gain.connect(master);
+      gain.gain.setValueAtTime(0.001, t);
+      gain.gain.linearRampToValueAtTime(peak, t + 0.03);
+      gain.gain.setValueAtTime(peak, t + dur - 0.06);
+      gain.gain.exponentialRampToValueAtTime(0.001, t + dur);
+      osc.start(t); osc.stop(t + dur);
+    };
+
+    const T = ctx.currentTime;
+    // Fast ascending arpeggio
+    [261, 330, 392, 523, 659, 784, 1047].forEach((hz, i) => note(hz, T + i * 0.07, 0.12, 0.18));
+    // Big final hit — thick chord
+    note(523, T + 0.56, 0.9, 0.30);
+    note(659, T + 0.56, 0.9, 0.25);
+    note(784, T + 0.56, 0.9, 0.20);
+    note(1047, T + 0.56, 0.7, 0.15);
+    // Shimmer on top
+    note(2093, T + 0.58, 0.5, 0.08, 'sine');
+
+    setTimeout(() => ctx.close(), 1800);
+  } catch (_) {}
+}
+
+const OVERDRAFT_CSS = `
+@keyframes sad-droop {
+  0%   { transform: translateY(-40px) scale(0.4); opacity: 0; }
+  60%  { transform: translateY(6px) scale(1.1); opacity: 1; }
+  78%  { transform: translateY(-3px) scale(0.97); }
+  100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+@keyframes sad-wobble {
+  0%, 100% { transform: rotate(-4deg); }
+  50%       { transform: rotate(4deg); }
+}
+@keyframes overdraft-flicker {
+  0%, 100% { opacity: 1; }
+  45%       { opacity: 0.35; }
+  50%       { opacity: 1; }
+  55%       { opacity: 0.2; }
+  60%       { opacity: 1; }
+}
+@keyframes fine-print-slide {
+  0%   { transform: translateY(20px); opacity: 0; }
+  100% { transform: translateY(0);    opacity: 1; }
+}
+`;
+
+const HIGH_ROLLER_THRESHOLD = 10000;
+
+const HIGH_ROLLER_CSS = `
+@keyframes credit-rain {
+  0%   { transform: translateY(-10px) rotate(0deg); opacity: 1; }
+  85%  { opacity: 0.8; }
+  100% { transform: translateY(340px) rotate(540deg); opacity: 0; }
+}
+@keyframes whale-pop {
+  0%   { transform: scale(0) rotate(-15deg); opacity: 0; }
+  65%  { transform: scale(1.18) rotate(5deg); opacity: 1; }
+  82%  { transform: scale(0.93) rotate(-2deg); }
+  100% { transform: scale(1) rotate(0deg); opacity: 1; }
+}
+@keyframes gold-shimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position:  200% center; }
+}
+`;
+
+const FIRST_PAY_CSS = `
+@keyframes coin-bounce {
+  0%   { transform: translateY(-80px) scale(0.5); opacity: 0; }
+  55%  { transform: translateY(10px)  scale(1.2); opacity: 1; }
+  72%  { transform: translateY(-5px)  scale(0.95); }
+  86%  { transform: translateY(3px)   scale(1.03); }
+  100% { transform: translateY(0)     scale(1); opacity: 1; }
+}
+@keyframes pay-shimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position:  200% center; }
+}
+`;
+
 interface BankWindowProps {
   pos: { x: number; y: number };
   setPos: (pos: { x: number; y: number }) => void;
@@ -132,11 +334,130 @@ interface BankWindowProps {
   socket: any;
   userName: string;
   isBankOpen: boolean;
+  firstPayDone?: boolean;
+  audioEnabled?: boolean;
+  soundVolumes?: Record<string, number>;
 }
 
-export function BankWindow({ pos, setPos, onClose, bankData, socket, userName, isBankOpen }: BankWindowProps) {
+const CONFETTI_COLORS = ['#ff0066', '#00ff66', '#ffcc00', '#00ccff', '#ff6600', '#cc00ff', '#ffffff'];
+
+const CELEBRATION_CSS = `
+@keyframes confetti-fall {
+  0%   { transform: translateY(-10px) rotate(0deg) scale(1);   opacity: 1; }
+  80%  { opacity: 1; }
+  100% { transform: translateY(320px) rotate(720deg) scale(0.5); opacity: 0; }
+}
+@keyframes congrats-pop {
+  0%   { transform: scale(0.3) rotate(-8deg); opacity: 0; }
+  60%  { transform: scale(1.12) rotate(3deg); opacity: 1; }
+  80%  { transform: scale(0.95) rotate(-1deg); }
+  100% { transform: scale(1) rotate(0deg); opacity: 1; }
+}
+@keyframes star-drop {
+  0%   { transform: translateY(-60px) scale(0.4) rotate(-20deg); opacity: 0; }
+  55%  { transform: translateY(12px)  scale(1.25) rotate(10deg);  opacity: 1; }
+  75%  { transform: translateY(-6px)  scale(0.95) rotate(-4deg); }
+  90%  { transform: translateY(3px)   scale(1.05) rotate(2deg);  }
+  100% { transform: translateY(0)     scale(1)    rotate(0deg);  opacity: 1; }
+}
+@keyframes star-glow {
+  0%, 100% { text-shadow: 0 0 8px #ffcc00, 0 0 20px #ffcc00; }
+  50%       { text-shadow: 0 0 20px #ffcc00, 0 0 50px #ff8800, 0 0 80px #ffcc00; }
+}
+@keyframes debt-free-shimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position:  200% center; }
+}
+`;
+
+export function BankWindow({ pos, setPos, onClose, bankData, socket, userName, isBankOpen, firstPayDone, audioEnabled, soundVolumes }: BankWindowProps) {
+  const vol = (key: string) => (soundVolumes?.[key] ?? 1);
+  const audioEnabledRef = useRef(audioEnabled);
+  useEffect(() => { audioEnabledRef.current = audioEnabled; }, [audioEnabled]);
   const [activePrompt, setActivePrompt] = useState<'withdraw' | 'borrow' | 'pay' | null>(null);
   const [promptAmount, setPromptAmount] = useState('');
+  const [showCelebration, setShowCelebration] = useState(false);
+  const [showHighRoller, setShowHighRoller] = useState(false);
+  const [showFirstPay, setShowFirstPay] = useState(false);
+  const [showOverdraft, setShowOverdraft] = useState(false);
+  const prevDebtRef = useRef(bankData.debt);
+  const prevBalanceRef = useRef(bankData.balance);
+  const hasHighRollerFiredRef = useRef(false);
+  const hasFirstPayFiredRef = useRef(!!firstPayDone);
+  const bankInitializedRef = useRef(false);
+
+  const confettiPieces = useMemo(() => Array.from({ length: 45 }, (_, i) => ({
+    left: Math.random() * 96,
+    size: 5 + Math.random() * 9,
+    color: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
+    round: Math.random() > 0.5,
+    duration: 1.8 + Math.random() * 1.8,
+    delay: Math.random() * 1.6,
+  })), [showCelebration]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const creditRainPieces = useMemo(() => Array.from({ length: 35 }, (_, i) => ({
+    left: Math.random() * 96,
+    duration: 1.6 + Math.random() * 1.8,
+    delay: Math.random() * 1.8,
+    size: 11 + Math.random() * 10,
+  })), [showHighRoller]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Debt paid off
+  useEffect(() => {
+    if (!bankInitializedRef.current) return;
+    if (prevDebtRef.current > 0 && bankData.debt === 0) {
+      if (audioEnabledRef.current) playProudFanfare(vol('debtpaid'));
+      setShowCelebration(true);
+      const t = setTimeout(() => setShowCelebration(false), 7000);
+      return () => clearTimeout(t);
+    }
+    prevDebtRef.current = bankData.debt;
+  }, [bankData.debt]);
+
+  // Balance increased → cash register sound + easter eggs
+  useEffect(() => {
+    if (!bankInitializedRef.current) {
+      // First real data load — seed refs silently, no sounds
+      bankInitializedRef.current = true;
+      prevDebtRef.current = bankData.debt;
+      prevBalanceRef.current = bankData.balance;
+      return;
+    }
+    const prev = prevBalanceRef.current;
+    const curr = bankData.balance;
+
+    if (curr > prev) {
+      if (audioEnabledRef.current) playCashRegister(vol('cashregister'));
+
+      // First Paycheck: balance was ≤ 0, now positive
+      if (prev <= 0 && curr > 0 && !hasFirstPayFiredRef.current) {
+        hasFirstPayFiredRef.current = true; socket.emit("markFirstPayDone", { username: userName });
+        if (audioEnabledRef.current) playCalibration(vol('firstpay'));
+        setShowFirstPay(true);
+        const t = setTimeout(() => setShowFirstPay(false), 6000);
+        return () => clearTimeout(t);
+      }
+
+      // High Roller: balance crosses threshold for first time this session
+      if (curr >= HIGH_ROLLER_THRESHOLD && !hasHighRollerFiredRef.current) {
+        hasHighRollerFiredRef.current = true;
+        if (audioEnabledRef.current) playHighRollerSound(vol('highroller'));
+        setShowHighRoller(true);
+        const t = setTimeout(() => setShowHighRoller(false), 7000);
+        return () => clearTimeout(t);
+      }
+    }
+
+    // Overdraft: balance just went negative
+    if (prev >= 0 && curr < 0) {
+      if (audioEnabledRef.current) playWompWomp(vol('overdraft'));
+      setShowOverdraft(true);
+      const t = setTimeout(() => setShowOverdraft(false), 7000);
+      return () => clearTimeout(t);
+    }
+
+    prevBalanceRef.current = curr;
+  }, [bankData.balance]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!isBankOpen) return null;
 
@@ -166,7 +487,7 @@ export function BankWindow({ pos, setPos, onClose, bankData, socket, userName, i
   const debtColor = roundedDebt > 0 ? '#ff0044' : '#fff';
 
   return (
-    <DraggableWindow title="CITY_NET // BANK" pos={pos} setPos={setPos} onClose={onClose} windowStyle={{ width: '400px' }}>
+    <DraggableWindow title="CITY_NET // BANK" pos={pos} setPos={setPos} onClose={onClose} windowStyle={{ width: '420px' }} contentStyle={{ overflow: 'hidden', maxHeight: 'none', minHeight: '220px' }}>
       <div style={{ display: 'flex', gap: '20px', padding: '10px' }}>
         <div style={{ flex: 1, border: '1px solid #333', padding: '10px', background: 'rgba(0,0,0,0.5)' }}>
           <div style={{ textAlign: 'center', fontSize: '12px', color: '#888', marginBottom: '5px', textTransform: 'uppercase' }}>Balance</div>
@@ -190,6 +511,8 @@ export function BankWindow({ pos, setPos, onClose, bankData, socket, userName, i
         </div>
       </div>
 
+      <CandleChart balance={bankData.balance} />
+
       {activePrompt && (
         <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.8)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 10 }}>
           <div style={{ background: '#111', border: '1px solid #444', padding: '20px', width: '200px' }}>
@@ -202,6 +525,333 @@ export function BankWindow({ pos, setPos, onClose, bankData, socket, userName, i
           </div>
         </div>
       )}
+
+      {showCelebration && (
+        <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 20, borderRadius: 'inherit' }}>
+          <style>{CELEBRATION_CSS}</style>
+
+          {/* Confetti rain */}
+          {confettiPieces.map((p, i) => (
+            <div key={i} style={{
+              position: 'absolute',
+              left: `${p.left}%`,
+              top: 0,
+              width: p.size,
+              height: p.size,
+              background: p.color,
+              borderRadius: p.round ? '50%' : '2px',
+              animation: `confetti-fall ${p.duration}s ${p.delay}s ease-in forwards`,
+              pointerEvents: 'none',
+            }} />
+          ))}
+
+          {/* Dark backing so text is readable */}
+          <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.72)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '10px', padding: '16px' }}>
+
+            <div style={{
+              fontSize: '26px', fontWeight: 'bold', fontFamily: 'monospace', textAlign: 'center',
+              background: 'linear-gradient(90deg, #00ff66, #00ccff, #00ff66)',
+              backgroundSize: '200% auto',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              animation: 'congrats-pop 0.6s cubic-bezier(0.34,1.56,0.64,1) both, debt-free-shimmer 2s linear 0.6s infinite',
+            }}>
+              🎉 CONGRATS!!! 🎉
+            </div>
+
+            <div style={{
+              fontSize: '13px', color: '#aaa', fontFamily: 'monospace', textAlign: 'center',
+              animation: 'congrats-pop 0.6s 0.15s cubic-bezier(0.34,1.56,0.64,1) both',
+            }}>
+              DEBT CLEARED — YOU ARE FREE
+            </div>
+
+            <div style={{
+              fontSize: '64px', lineHeight: 1,
+              animation: 'star-drop 0.8s 0.4s cubic-bezier(0.34,1.56,0.64,1) both, star-glow 1.6s 1.2s ease-in-out infinite',
+              display: 'inline-block',
+            }}>
+              ⭐
+            </div>
+
+            <div style={{
+              fontSize: '15px', color: '#ffcc00', fontFamily: 'monospace', fontWeight: 'bold', textAlign: 'center',
+              animation: 'congrats-pop 0.6s 0.7s cubic-bezier(0.34,1.56,0.64,1) both',
+            }}>
+              You Deserve a Star
+            </div>
+
+            <button
+              className="panel-btn"
+              onClick={() => setShowCelebration(false)}
+              style={{ marginTop: '8px', animation: 'congrats-pop 0.5s 1s both' }}
+            >
+              THANKS ✓
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── HIGH ROLLER ── */}
+      {showHighRoller && (
+        <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 20, borderRadius: 'inherit' }}>
+          <style>{HIGH_ROLLER_CSS}</style>
+
+          {creditRainPieces.map((p, i) => (
+            <div key={i} style={{
+              position: 'absolute', left: `${p.left}%`, top: 0,
+              fontSize: p.size, color: '#ffcc00', pointerEvents: 'none',
+              animation: `credit-rain ${p.duration}s ${p.delay}s ease-in forwards`,
+            }}>₡</div>
+          ))}
+
+          <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.78)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '14px', padding: '20px' }}>
+            <div style={{ fontSize: '52px', animation: 'whale-pop 0.65s cubic-bezier(0.34,1.56,0.64,1) both' }}>🐋</div>
+
+            <div style={{
+              fontSize: '22px', fontWeight: 'bold', fontFamily: 'monospace', textAlign: 'center',
+              background: 'linear-gradient(90deg, #ffcc00, #ff8800, #ffcc00)',
+              backgroundSize: '200% auto',
+              WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
+              animation: 'whale-pop 0.65s 0.1s cubic-bezier(0.34,1.56,0.64,1) both, gold-shimmer 2s linear 0.75s infinite',
+            }}>
+              WHALE STATUS ACHIEVED
+            </div>
+
+            <div style={{ fontSize: '13px', color: '#ffcc00', fontFamily: 'monospace', textAlign: 'center', opacity: 0.8, animation: 'whale-pop 0.5s 0.3s both' }}>
+              BALANCE EXCEEDED ₡{HIGH_ROLLER_THRESHOLD.toLocaleString()}
+            </div>
+            <div style={{ fontSize: '12px', color: '#888', fontFamily: 'monospace', textAlign: 'center', animation: 'whale-pop 0.5s 0.45s both' }}>
+              The city knows your name now.
+            </div>
+
+            <button className="panel-btn" onClick={() => setShowHighRoller(false)} style={{ marginTop: '8px', borderColor: '#ffcc00', color: '#ffcc00', animation: 'whale-pop 0.5s 0.8s both' }}>
+              I KNOW 💰
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── FIRST PAYCHECK ── */}
+      {showFirstPay && (
+        <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 20, borderRadius: 'inherit' }}>
+          <style>{FIRST_PAY_CSS}</style>
+
+          <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.78)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '14px', padding: '20px' }}>
+            <div style={{ fontSize: '52px', animation: 'coin-bounce 0.7s cubic-bezier(0.34,1.56,0.64,1) both' }}>🎊</div>
+
+            <div style={{
+              fontSize: '20px', fontWeight: 'bold', fontFamily: 'monospace', textAlign: 'center',
+              background: 'linear-gradient(90deg, #00ff66, #00ccff, #00ff66)',
+              backgroundSize: '200% auto',
+              WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
+              animation: 'coin-bounce 0.7s 0.12s cubic-bezier(0.34,1.56,0.64,1) both, pay-shimmer 2s linear 0.82s infinite',
+            }}>
+              FIRST PAYDAY
+            </div>
+
+            <div style={{ fontSize: '13px', color: '#00ff66', fontFamily: 'monospace', textAlign: 'center', animation: 'coin-bounce 0.5s 0.3s both' }}>
+              Welcome to the economy, choom.
+            </div>
+            <div style={{ fontSize: '12px', color: '#888', fontFamily: 'monospace', textAlign: 'center', animation: 'coin-bounce 0.5s 0.45s both' }}>
+              Try not to spend it all at once.
+            </div>
+
+            <button className="panel-btn" onClick={() => setShowFirstPay(false)} style={{ marginTop: '8px', animation: 'coin-bounce 0.5s 0.8s both' }}>
+              THANKS, I WILL 🫡
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── OVERDRAFT ── */}
+      {showOverdraft && (
+        <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 20, borderRadius: 'inherit' }}>
+          <style>{OVERDRAFT_CSS}</style>
+
+          <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.82)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '8px', padding: '16px' }}>
+
+            {/* Row of drooping sad faces */}
+            <div style={{ display: 'flex', gap: '8px' }}>
+              {['😢', '😞', '😔'].map((emoji, i) => (
+                <div key={i} style={{
+                  fontSize: '32px',
+                  animation: `sad-droop 0.6s ${i * 0.12}s cubic-bezier(0.34,1.56,0.64,1) both, sad-wobble 2.4s ${0.8 + i * 0.1}s ease-in-out infinite`,
+                  display: 'inline-block',
+                }}>{emoji}</div>
+              ))}
+            </div>
+
+            <div style={{
+              fontSize: '18px', fontWeight: 'bold', fontFamily: 'monospace', color: '#ff4444', textAlign: 'center',
+              animation: 'overdraft-flicker 2s 0.5s ease-in-out infinite',
+            }}>
+              BALANCE NEGATIVE
+            </div>
+
+            <div style={{
+              fontSize: '13px', color: '#ff8888', fontFamily: 'monospace', textAlign: 'center', maxWidth: '280px',
+              animation: 'fine-print-slide 0.5s 0.6s both',
+            }}>
+              We'll overlook the overdraft fee.
+            </div>
+            <div style={{
+              fontSize: '11px', color: '#888', fontFamily: 'monospace', textAlign: 'center', fontStyle: 'italic',
+              animation: 'fine-print-slide 0.5s 0.85s both',
+            }}>
+              This time...
+            </div>
+
+            <button className="panel-btn" onClick={() => setShowOverdraft(false)} style={{ marginTop: '8px', borderColor: '#ff4444', color: '#ff4444', animation: 'fine-print-slide 0.4s 1.1s both' }}>
+              I'M SORRY 😔
+            </button>
+          </div>
+        </div>
+      )}
     </DraggableWindow>
+  );
+}
+
+// ── CANDLE CHART ──────────────────────────────────────────────────────────────
+
+interface Candle { open: number; close: number; high: number; low: number; }
+
+const CANDLE_COUNT = 28;
+const CANDLE_INTERVAL_MS = 2500;
+
+function generateNextCandle(prev: Candle, biasDelta: number): Candle {
+  const drift = biasDelta * 0.012 + (Math.random() - 0.48) * 4.5;
+  const bodySize = 1.5 + Math.random() * 5;
+  const open = prev.close;
+  const close = open + drift + (Math.random() - 0.5) * bodySize;
+  const high = Math.max(open, close) + Math.random() * 3;
+  const low = Math.min(open, close) - Math.random() * 3;
+  return { open, close, high, low };
+}
+
+function seedCandles(startPrice: number): Candle[] {
+  const candles: Candle[] = [];
+  let price = startPrice;
+  for (let i = 0; i < CANDLE_COUNT; i++) {
+    const drift = (Math.random() - 0.48) * 3.5;
+    const bodySize = 1.5 + Math.random() * 5;
+    const open = price;
+    const close = open + drift + (Math.random() - 0.5) * bodySize;
+    const high = Math.max(open, close) + Math.random() * 3;
+    const low = Math.min(open, close) - Math.random() * 3;
+    candles.push({ open, close, high, low });
+    price = close;
+  }
+  return candles;
+}
+
+const FAKE_TICKERS: { name: string; ticker: string }[] = [
+  { name: 'NEON DYNAMICS',       ticker: 'NDX' },
+  { name: 'GHOST PROTOCOL TECH', ticker: 'GPT' },
+  { name: 'AXIOM CORP',          ticker: 'AXM' },
+  { name: 'SYNTHEX INDUSTRIES',  ticker: 'SYX' },
+  { name: 'VORTEX CAPITAL',      ticker: 'VTX' },
+  { name: 'HELIX BIOSYNTH',      ticker: 'HLX' },
+  { name: 'OMNIVAULT SYSTEMS',   ticker: 'OVS' },
+  { name: 'DARKPOOL FINANCE',    ticker: 'DPF' },
+  { name: 'CHROME FUTURES',      ticker: 'CRF' },
+  { name: 'PARALLAX HOLDINGS',   ticker: 'PRX' },
+  { name: 'CIPHER NETWORKS',     ticker: 'CPH' },
+  { name: 'ZERO POINT ENERGY',   ticker: 'ZPE' },
+  { name: 'REDLINE MOTORS',      ticker: 'RLM' },
+  { name: 'SPECTRE ARMS',        ticker: 'SPA' },
+  { name: 'NEURAL LATTICE',      ticker: 'NLT' },
+  { name: 'BLACKSITE VENTURES',  ticker: 'BSV' },
+  { name: 'MIRAGE LOGISTICS',    ticker: 'MRL' },
+  { name: 'PULSE PHARMA',        ticker: 'PLP' },
+  { name: 'VOID TECHNOLOGIES',   ticker: 'VDT' },
+  { name: 'APEX MUNITIONS',      ticker: 'APX' },
+];
+
+function CandleChart({ balance }: { balance: number }) {
+  const [candles, setCandles] = useState<Candle[]>(() => seedCandles(100));
+  const [ticker] = useState(() => FAKE_TICKERS[Math.floor(Math.random() * FAKE_TICKERS.length)]);
+  const prevBalanceRef = useRef(balance);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const biasDelta = balance - prevBalanceRef.current;
+      prevBalanceRef.current = balance;
+      setCandles(prev => [...prev.slice(1), generateNextCandle(prev[prev.length - 1], biasDelta)]);
+    }, CANDLE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [balance]);
+
+  const W = 390;
+  const H = 110;
+  const PAD = { top: 8, bottom: 8, left: 6, right: 40 };
+  const chartW = W - PAD.left - PAD.right;
+  const chartH = H - PAD.top - PAD.bottom;
+  const candleW = chartW / CANDLE_COUNT;
+  const bodyW = Math.max(2, candleW * 0.55);
+
+  const allPrices = candles.flatMap(c => [c.high, c.low]);
+  const minP = Math.min(...allPrices);
+  const maxP = Math.max(...allPrices);
+  const range = maxP - minP || 1;
+  const toY = (p: number) => PAD.top + chartH - ((p - minP) / range) * chartH;
+
+  const lastCandle = candles[candles.length - 1];
+  const lastPrice = lastCandle.close;
+  const firstPrice = candles[0].open;
+  const sessionUp = lastPrice >= firstPrice;
+  const upColor = '#00ff66';
+  const downColor = '#ff3333';
+  const priceColor = sessionUp ? upColor : downColor;
+
+  return (
+    <div style={{ padding: '0 10px 10px', userSelect: 'none' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '4px' }}>
+        <span style={{ fontSize: '9px', color: '#444', fontFamily: 'monospace', letterSpacing: '1px' }}>{ticker.name} &nbsp; {ticker.ticker}</span>
+        <span style={{ fontSize: '10px', fontFamily: 'monospace', color: priceColor, textShadow: `0 0 6px ${priceColor}` }}>
+          {sessionUp ? '▲' : '▼'} {Math.abs(lastPrice - firstPrice).toFixed(2)}
+        </span>
+      </div>
+      <svg width="100%" viewBox={`0 0 ${W} ${H}`} style={{ display: 'block', background: 'rgba(0,0,0,0.4)', border: '1px solid #1a1a1a' }}>
+        {[0.25, 0.5, 0.75].map(t => (
+          <line key={t} x1={PAD.left} x2={W - PAD.right} y1={PAD.top + chartH * t} y2={PAD.top + chartH * t} stroke="#0d200d" strokeWidth="1" />
+        ))}
+
+        {candles.map((c, i) => {
+          const x = PAD.left + i * candleW + candleW / 2;
+          const bull = c.close >= c.open;
+          const color = bull ? upColor : downColor;
+          const bodyTop = toY(Math.max(c.open, c.close));
+          const bodyBot = toY(Math.min(c.open, c.close));
+          const bodyH = Math.max(1, bodyBot - bodyTop);
+          return (
+            <g key={i}>
+              <line x1={x} x2={x} y1={toY(c.high)} y2={toY(c.low)} stroke={color} strokeWidth="1" opacity="0.6" />
+              <rect
+                x={x - bodyW / 2} y={bodyTop} width={bodyW} height={bodyH}
+                fill={bull ? color : 'none'} stroke={color} strokeWidth="1"
+              />
+            </g>
+          );
+        })}
+
+        <line x1={PAD.left} x2={W - PAD.right} y1={toY(lastPrice)} y2={toY(lastPrice)}
+          stroke={priceColor} strokeWidth="1" strokeDasharray="3 3" opacity="0.6" />
+
+        <text x={W - PAD.right + 4} y={toY(lastPrice) + 3} textAnchor="start"
+          fill={priceColor} fontSize="8" fontFamily="monospace">
+          {lastPrice.toFixed(1)}
+        </text>
+
+        <text x={W - PAD.right + 4} y={PAD.top + 4} textAnchor="start"
+          fill="#333" fontSize="7" fontFamily="monospace">
+          {maxP.toFixed(0)}
+        </text>
+        <text x={W - PAD.right + 4} y={H - PAD.bottom} textAnchor="start"
+          fill="#333" fontSize="7" fontFamily="monospace">
+          {minP.toFixed(0)}
+        </text>
+      </svg>
+    </div>
   );
 }

--- a/frontend/src/components/Rhombuses.tsx
+++ b/frontend/src/components/Rhombuses.tsx
@@ -30,6 +30,7 @@ export const EnemyRhombus = React.memo(({ location, onClick, isSelected, setTarg
         return () => window.removeEventListener('pointerup', handleGlobalUp);
     }, [controls, setIsDragging]);
   const localPos = useRef({ x: location.x, z: location.z });
+  const pathPoints = useRef<{ x: number; z: number }[]>([]);
   const [dragOffset, setDragOffset] = useState(new THREE.Vector3());
 
   // Smooth movement interpolation
@@ -38,6 +39,8 @@ export const EnemyRhombus = React.memo(({ location, onClick, isSelected, setTarg
   const [animState, setAnimState] = useState<'none' | 'appearing' | 'fading'>('none');
   const animStartTime = useRef<number | null>(null);
   const hasAppeared = useRef(false);
+  const waypointTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const isAnimatingPath = useRef(false);
 
   const isOnline = true; // Enemies are system-owned and always 'online'
 
@@ -54,18 +57,40 @@ export const EnemyRhombus = React.memo(({ location, onClick, isSelected, setTarg
     if (!socket) return;
     const handleFade = (data: any) => { if (data.id === location.id) { setAnimState('fading'); animStartTime.current = Date.now(); } };
     const handleAppear = (data: any) => { if (data.id === location.id) { setAnimState('appearing'); animStartTime.current = Date.now(); } };
+    const handlePath = (data: any) => {
+      if (data.id !== location.id || !Array.isArray(data.waypoints)) return;
+      waypointTimers.current.forEach(clearTimeout);
+      waypointTimers.current = [];
+      isAnimatingPath.current = true;
+      const interval = 80; // ms between waypoints
+      data.waypoints.forEach((wp: { x: number; z: number }, i: number) => {
+        const t = setTimeout(() => {
+          localPos.current = { x: wp.x, z: wp.z };
+          if (i === data.waypoints.length - 1) isAnimatingPath.current = false;
+        }, i * interval);
+        waypointTimers.current.push(t);
+      });
+    };
     socket.on('rhombusFading', handleFade);
     socket.on('rhombusAppearing', handleAppear);
-    return () => { socket.off('rhombusFading', handleFade); socket.off('rhombusAppearing', handleAppear); };
+    socket.on('rhombusPath', handlePath);
+    return () => {
+      socket.off('rhombusFading', handleFade);
+      socket.off('rhombusAppearing', handleAppear);
+      socket.off('rhombusPath', handlePath);
+      waypointTimers.current.forEach(clearTimeout);
+      isAnimatingPath.current = false;
+    };
   }, [location.id, socket]);
 
-  useEffect(() => { 
-    localPos.current = { x: location.x, z: location.z }; 
+  useEffect(() => {
+    if (isAnimatingPath.current) return;
+    localPos.current = { x: location.x, z: location.z };
   }, [location.x, location.z]);
 
   useFrame((state, delta) => {
     if (!meshRef.current) return;
-    
+
     // Interpolate towards localPos (35% slower + frame-rate independent)
     const targetY = location.y + (location.height / 4);
     visualPos.current.x = THREE.MathUtils.lerp(visualPos.current.x, localPos.current.x, 2.6 * delta);
@@ -144,10 +169,11 @@ export const EnemyRhombus = React.memo(({ location, onClick, isSelected, setTarg
       if (measureMode) return;
       e.stopPropagation();
     dragDist.current = 0;
-    
+
     // Only allow dragging if the user is an Admin
     if (!isAdmin) return;
 
+    pathPoints.current = [{ x: localPos.current.x, z: localPos.current.z }];
     try { e.target.setPointerCapture(e.pointerId); } catch (err) {}
     const currentRaycaster = e.raycaster || raycaster;
     if (currentRaycaster && currentRaycaster.ray) {
@@ -169,6 +195,7 @@ export const EnemyRhombus = React.memo(({ location, onClick, isSelected, setTarg
         const targetX = intersection.x + dragOffset.x;
         const targetZ = intersection.z + dragOffset.z;
         localPos.current = { x: targetX, z: targetZ };
+        pathPoints.current.push({ x: targetX, z: targetZ });
     }
   };
 
@@ -178,25 +205,29 @@ export const EnemyRhombus = React.memo(({ location, onClick, isSelected, setTarg
     if (controls) (controls as any).enabled = true;
     setIsLocalDragging(false);
     setIsDragging(false);
-    
+
     // EVERYONE can open the info window with a click
     if (dragDist.current < 15) {
         e.stopPropagation();
         onClick(); // Stationary click -> open info window
     } else if (isAdmin) {
-        // Only admins can actually SAVE the new position after a drag
-        socket.emit('moveRhombus', { id: location.id, x: localPos.current.x, z: localPos.current.z });
+        const pts = pathPoints.current;
+        const waypoints = Array.from({ length: 30 }, (_, i) => {
+          const idx = Math.round(i * (pts.length - 1) / 29);
+          return pts[idx];
+        });
+        socket.emit('moveRhombusPath', { id: location.id, waypoints });
     }
   };
 
   return (
-    <group 
-        ref={(group) => { 
+    <group
+        ref={(group) => {
             groupRef.current = group as any;
             if (group) {
                 if (group.position) group.position.copy(visualPos.current);
             }
-            if (isSelected && group) { setTargetObject(group); } 
+            if (isSelected && group) { setTargetObject(group); }
         }}
     >
       <mesh 
@@ -262,13 +293,16 @@ export const FriendlyRhombus = React.memo(({ location, onClick, isSelected, setT
       return () => window.removeEventListener('pointerup', handleGlobalUp);
   }, [controls, setIsDragging]);
   const localPos = useRef({ x: location.x, z: location.z });
+  const pathPoints = useRef<{ x: number; z: number }[]>([]);
   const [dragOffset, setDragOffset] = useState(new THREE.Vector3());
+  const waypointTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   const visualPos = useRef(new THREE.Vector3(location.x, location.y + (location.height / 4), location.z));
 
   const [animState, setAnimState] = useState<'none' | 'appearing' | 'fading'>('none');
   const animStartTime = useRef<number | null>(null);
   const hasAppeared = useRef(false);
+  const isAnimatingPath = useRef(false);
 
   useEffect(() => {
     if (!hasAppeared.current) {
@@ -282,13 +316,35 @@ export const FriendlyRhombus = React.memo(({ location, onClick, isSelected, setT
     if (!socket) return;
     const handleFade = (data: any) => { if (data.id === location.id) { setAnimState('fading'); animStartTime.current = Date.now(); } };
     const handleAppear = (data: any) => { if (data.id === location.id) { setAnimState('appearing'); animStartTime.current = Date.now(); } };
+    const handlePath = (data: any) => {
+      if (data.id !== location.id || !Array.isArray(data.waypoints)) return;
+      waypointTimers.current.forEach(clearTimeout);
+      waypointTimers.current = [];
+      isAnimatingPath.current = true;
+      const interval = 80;
+      data.waypoints.forEach((wp: { x: number; z: number }, i: number) => {
+        const t = setTimeout(() => {
+          localPos.current = { x: wp.x, z: wp.z };
+          if (i === data.waypoints.length - 1) isAnimatingPath.current = false;
+        }, i * interval);
+        waypointTimers.current.push(t);
+      });
+    };
     socket.on('rhombusFading', handleFade);
     socket.on('rhombusAppearing', handleAppear);
-    return () => { socket.off('rhombusFading', handleFade); socket.off('rhombusAppearing', handleAppear); };
+    socket.on('rhombusPath', handlePath);
+    return () => {
+      socket.off('rhombusFading', handleFade);
+      socket.off('rhombusAppearing', handleAppear);
+      socket.off('rhombusPath', handlePath);
+      waypointTimers.current.forEach(clearTimeout);
+      isAnimatingPath.current = false;
+    };
   }, [location.id, socket]);
 
-  useEffect(() => { 
-    localPos.current = { x: location.x, z: location.z }; 
+  useEffect(() => {
+    if (isAnimatingPath.current) return;
+    localPos.current = { x: location.x, z: location.z };
   }, [location.x, location.z]);
 
   useFrame((state, delta) => {
@@ -373,6 +429,7 @@ export const FriendlyRhombus = React.memo(({ location, onClick, isSelected, setT
       e.stopPropagation();
     dragDist.current = 0;
     if (!isAdmin) return;
+    pathPoints.current = [{ x: localPos.current.x, z: localPos.current.z }];
     try { e.target.setPointerCapture(e.pointerId); } catch (err) {}
     const currentRaycaster = e.raycaster || raycaster;
     if (currentRaycaster && currentRaycaster.ray) {
@@ -394,6 +451,7 @@ export const FriendlyRhombus = React.memo(({ location, onClick, isSelected, setT
         const targetX = intersection.x + dragOffset.x;
         const targetZ = intersection.z + dragOffset.z;
         localPos.current = { x: targetX, z: targetZ };
+        pathPoints.current.push({ x: targetX, z: targetZ });
     }
   };
 
@@ -403,12 +461,17 @@ export const FriendlyRhombus = React.memo(({ location, onClick, isSelected, setT
     if (controls) (controls as any).enabled = true;
     setIsLocalDragging(false);
     setIsDragging(false);
-    
+
     if (dragDist.current < 15) {
         e.stopPropagation();
-        onClick(); 
+        onClick();
     } else if (isAdmin) {
-        socket.emit('moveRhombus', { id: location.id, x: localPos.current.x, z: localPos.current.z });
+        const pts = pathPoints.current;
+        const waypoints = Array.from({ length: 30 }, (_, i) => {
+          const idx = Math.round(i * (pts.length - 1) / 29);
+          return pts[idx];
+        });
+        socket.emit('moveRhombusPath', { id: location.id, waypoints });
     }
   };
 
@@ -483,7 +546,10 @@ export const PlayerRhombus = React.memo(({ location, onClick, isSelected, setTar
         return () => window.removeEventListener('pointerup', handleGlobalUp);
     }, [controls, setIsDragging]);
   const localPos = useRef({ x: location.x, z: location.z });
+  const pathPoints = useRef<{ x: number; z: number }[]>([]);
   const [dragOffset, setDragOffset] = useState(new THREE.Vector3());
+  const waypointTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const isAnimatingPath = useRef(false);
 
   // Smooth movement interpolation
   const visualPos = useRef(new THREE.Vector3(
@@ -493,6 +559,7 @@ export const PlayerRhombus = React.memo(({ location, onClick, isSelected, setTar
   ));
 
   useEffect(() => {
+    if (isAnimatingPath.current) return;
     localPos.current = { x: location.x, z: location.z };
   }, [location.x, location.z]);
 
@@ -513,9 +580,30 @@ export const PlayerRhombus = React.memo(({ location, onClick, isSelected, setTar
     if (!socket) return;
     const handleFade = (data: any) => { if (data.id === location.id) { setAnimState('fading'); animStartTime.current = Date.now(); } };
     const handleAppear = (data: any) => { if (data.id === location.id) { setAnimState('appearing'); animStartTime.current = Date.now(); } };
+    const handlePath = (data: any) => {
+      if (data.id !== location.id || !Array.isArray(data.waypoints)) return;
+      waypointTimers.current.forEach(clearTimeout);
+      waypointTimers.current = [];
+      isAnimatingPath.current = true;
+      const interval = 80;
+      data.waypoints.forEach((wp: { x: number; z: number }, i: number) => {
+        const t = setTimeout(() => {
+          localPos.current = { x: wp.x, z: wp.z };
+          if (i === data.waypoints.length - 1) isAnimatingPath.current = false;
+        }, i * interval);
+        waypointTimers.current.push(t);
+      });
+    };
     socket.on('rhombusFading', handleFade);
     socket.on('rhombusAppearing', handleAppear);
-    return () => { socket.off('rhombusFading', handleFade); socket.off('rhombusAppearing', handleAppear); };
+    socket.on('rhombusPath', handlePath);
+    return () => {
+      socket.off('rhombusFading', handleFade);
+      socket.off('rhombusAppearing', handleAppear);
+      socket.off('rhombusPath', handlePath);
+      waypointTimers.current.forEach(clearTimeout);
+      isAnimatingPath.current = false;
+    };
   }, [location.id, socket]);
 
   useFrame((state, delta) => {
@@ -614,10 +702,11 @@ export const PlayerRhombus = React.memo(({ location, onClick, isSelected, setTar
       if (measureMode) return;
       e.stopPropagation();
     dragDist.current = 0;
-    
+
     // Only allow dragging if the user has management rights (Owner or Admin)
     if (!canManage) return;
 
+    pathPoints.current = [{ x: localPos.current.x, z: localPos.current.z }];
     try { e.target.setPointerCapture(e.pointerId); } catch (err) {}
     const currentRaycaster = e.raycaster || raycaster;
     if (currentRaycaster && currentRaycaster.ray) {
@@ -639,6 +728,7 @@ export const PlayerRhombus = React.memo(({ location, onClick, isSelected, setTar
         const targetX = intersection.x + dragOffset.x;
         const targetZ = intersection.z + dragOffset.z;
         localPos.current = { x: targetX, z: targetZ };
+        pathPoints.current.push({ x: targetX, z: targetZ });
     }
   };
 
@@ -648,14 +738,18 @@ export const PlayerRhombus = React.memo(({ location, onClick, isSelected, setTar
     if (controls) (controls as any).enabled = true;
     setIsLocalDragging(false);
     setIsDragging(false);
-    
+
     // EVERYONE can open the info window with a click
     if (dragDist.current < 15) {
         e.stopPropagation();
         onClick(); // Stationary click -> open info window
     } else if (canManage) {
-        // Only owners/admins can actually SAVE the new position after a drag
-        socket.emit('moveRhombus', { id: location.id, x: localPos.current.x, z: localPos.current.z });
+        const pts = pathPoints.current;
+        const waypoints = Array.from({ length: 30 }, (_, i) => {
+          const idx = Math.round(i * (pts.length - 1) / 29);
+          return pts[idx];
+        });
+        socket.emit('moveRhombusPath', { id: location.id, waypoints });
     }
   };
 

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -12,11 +12,14 @@ interface UseSocketOptions {
   notificationsEnabled: boolean;
   isChatOpen: boolean;
   onFetchAll: () => void;
+  onFetchGlobalSettings?: () => void;
   onFetchLocations: () => void;
   onFetchRoads: () => void;
   onFetchDistricts: () => void;
   onFetchWaterBodies: () => void;
-  onBankUpdate: (balance: number, debt: number) => void;
+  onFetchBattleMaps?: () => void;
+  onBankUpdate: (balance: number, debt: number, firstPayDone?: boolean) => void;
+  onBalancePaid?: (balance: number, debt: number, firstPayDone?: boolean) => void;
   onNotification: (msg: string | null) => void;
   onHasUnreadChat: (val: boolean) => void;
   onTokenUpdate: (token: string) => void;
@@ -25,8 +28,8 @@ interface UseSocketOptions {
 
 export function useSocket({
   userName, token, isLoggedIn, notificationsEnabled, isChatOpen,
-  onFetchAll, onFetchLocations, onFetchRoads, onFetchDistricts, onFetchWaterBodies,
-  onBankUpdate, onNotification, onHasUnreadChat, onTokenUpdate, onIsAdminUpdate,
+  onFetchAll, onFetchGlobalSettings, onFetchLocations, onFetchRoads, onFetchDistricts, onFetchWaterBodies, onFetchBattleMaps,
+  onBankUpdate, onBalancePaid, onNotification, onHasUnreadChat, onTokenUpdate, onIsAdminUpdate,
 }: UseSocketOptions) {
   const socketRef = useRef<ReturnType<typeof io> | null>(null);
   const tokenRef = useRef(token);
@@ -61,12 +64,19 @@ export function useSocket({
       newSocket.emit('identify', { userName: userNameRef.current, isAdmin: !!tokenRef.current, token: tokenRef.current });
     });
 
+    newSocket.on('settingsUpdated', () => {
+      onFetchGlobalSettings?.();
+    });
+
     newSocket.on('dataUpdated', (payload: { isRhombusOnly?: boolean }) => {
       onFetchLocations();
       onFetchRoads();
       onFetchDistricts();
       onFetchWaterBodies();
-      if (!payload?.isRhombusOnly) (window as any).hasUnsavedChanges = true;
+      if (!payload?.isRhombusOnly) {
+        (window as any).hasUnsavedChanges = true;
+        onFetchBattleMaps?.();
+      }
     });
 
     newSocket.on('activeUsersUpdated', (users: ActiveUser[]) => setActiveUsers(users));
@@ -86,8 +96,14 @@ export function useSocket({
       }
     });
 
-    newSocket.on('bankUpdate', (data: { username: string; balance: number; debt: number }) => {
-      if (data.username === userNameRef.current) onBankUpdate(data.balance, data.debt);
+    let lastKnownBalance: number | null = null;
+    newSocket.on('bankUpdate', (data: { username: string; balance: number; debt: number; firstPayDone?: boolean }) => {
+      if (data.username !== userNameRef.current) return;
+      onBankUpdate(data.balance, data.debt, data.firstPayDone);
+      if (lastKnownBalance !== null && data.balance > lastKnownBalance) {
+        onBalancePaid?.(data.balance, data.debt, data.firstPayDone);
+      }
+      lastKnownBalance = data.balance;
     });
     newSocket.emit('requestBankBalance', { username: userName });
 


### PR DESCRIPTION
…dle chart

- Rhombuses now record full drag path (30 waypoints) and animate on other clients
- Battle map image dedup via SHA-256 hash; select-existing thumbnail picker added
- Elevator menu updates live without server restart
- Bank window easter eggs: debt-paid celebration, cash register sound, High Roller, First Payday (persisted to DB, never repeats), Overdraft with womp-womp sound
- Bank auto-pops open when admin pays a player
- All bank sounds accept vol multiplier; admin panel BANK SOUNDS section with per-sound test buttons, volume sliders, saved to global_settings and broadcast live to all players via settingsUpdated socket event
- CITY_NET // EXCHANGE candle chart in bank window with 20 random fake tickers
- Admin panel scrollable (maxHeight 90vh); PAY_PLAYERS moved above BANK SOUNDS
- Danger buttons get black text-shadow for readability
- Fixed: bank sounds firing on login (bankInitializedRef guard)
- Fixed: bank sounds firing on mute/unmute (audioEnabledRef pattern)
- Fixed: overlay alignment (position:relative on .win95-content)
- Fixed: logout ReferenceError (socket → socketRef.current)
- Fixed: admin panel bank sound volume changes now push live to all clients