### PR TITLE
fix: Watchtower Docker socket path for Windows host + bump to 1.0.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,6 @@ services:
   watchtower:
     image: containrrr/watchtower
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - //var/run/docker.sock:/var/run/docker.sock
     command: --interval 30
     restart: unless-stopped

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
Windows Docker Desktop requires //var/run/docker.sock (double slash) for the socket mount in Linux containers — single slash causes API version mismatch errors. Version bumped to 1.0.5 (bug/QoL).