### PR TITLE
fix: Watchtower checks at 4am local time instead of every 30s

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A `docker-compose.yml` is included. Copy `.env.example` to `backend/.env`, fill 
 docker compose up -d
 ```
 
-The compose file includes [Watchtower](https://containrrr.dev/watchtower/) — it watches your containers and automatically pulls updated images when you push a new build to Docker Hub.
+The compose file includes [Watchtower](https://containrrr.dev/watchtower/) — it watches your containers and automatically pulls updated images when you push a new build to Docker Hub. Watchtower checks for updates at **4am local time** (the device's timezone) and on every startup, so powering the machine back on after downtime will also trigger a check. Updates restart the containers, which disconnects active sessions — schedule releases between sessions to avoid disrupting players.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,5 @@ services:
     image: containrrr/watchtower
     volumes:
       - //var/run/docker.sock:/var/run/docker.sock
-    command: --interval 30
+    command: --schedule "0 0 4 * * *"
     restart: unless-stopped


### PR DESCRIPTION
Polling every 30 seconds would restart containers mid-session and disconnect players. 4am local (device timezone) ensures updates happen during off-hours. Watchtower also checks on startup so the image is current after any downtime. README updated with a note explaining the behaviour.