### PR TITLE
fix: add renderSidewalks to viewSettingsUpdated socket type on featur…

### DIFF
--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -119,7 +119,7 @@ export function useSocket({
       }
     });
 
-    newSocket.on('viewSettingsUpdated', (settings: { renderSignage: boolean; signageDensity: number }) => {
+    newSocket.on('viewSettingsUpdated', (settings: { renderSignage: boolean; signageDensity: number; renderSidewalks: boolean }) => {
       onViewSettingsUpdate?.(settings);
     });
 


### PR DESCRIPTION
…e branch

tsc -b was failing in Docker build because the type was missing renderSidewalks.