### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.0] - 2026-07-06
+
+### Fixed
+- **APP_VERSION sync in release workflow** — Docker images now automatically deploy with APP_VERSION matching package.json version, eliminating false "update available" notifications
+
+---
+
 ## [1.1.9] - 2026-07-06
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.1.9",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
- Updated frontend/package.json version
- Added CHANGELOG entry for 1.2.0 release
- GitHub Actions workflow will sync APP_VERSION and build images on main merge

## Summary
<!-- Describe what changed and why -->

## Test plan
<!-- How should this be tested? -->
- [ ] Tested locally
- [ ] Tests pass

## Pre-merge checklist

**Code quality:**
- [ ] Code follows project style
- [ ] No breaking changes (or clearly documented)
- [ ] No console errors or warnings

**Version & Release:**
- [ ] **Version bumped?** If releasing to users, update:
  - [ ] `frontend/package.json` version
  - [ ] `docker-compose.yml` `APP_VERSION`
  - [ ] `CHANGELOG.md` with release notes
- [ ] GitHub Actions will auto-tag Docker images with the new version

**Before merging to main:**
- [ ] All tests passing
- [ ] PR reviewed and approved
- [ ] Branch is up to date with main
- [ ] No merge conflicts

## Related issues
<!-- Link any related issues: Fixes #123 -->
