### PR TITLE
ci: gate release on CI Tests passing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release to Docker Hub
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI Tests"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       tag:
@@ -15,6 +16,7 @@ jobs:
   release:
     name: Build & Push
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Release workflow now triggers via workflow_run instead of push, so Docker Hub images only build if all tests pass first. workflow_dispatch bypasses the gate for manual releases.

## Summary
<!-- Describe what changed and why -->

## Test plan
<!-- How should this be tested? -->
- [x] Tested locally
- [x] Tests pass

## Pre-merge checklist

**Code quality:**
- [x] Code follows project style
- [x] No breaking changes (or clearly documented)
- [x] No console errors or warnings

**Version & Release:**
- [x] **Version bumped?** If releasing to users, update:
  - [x] `frontend/package.json` version
  - [x] `docker-compose.yml` `APP_VERSION`
  - [x] `CHANGELOG.md` with release notes
- [x] GitHub Actions will auto-tag Docker images with the new version

**Before merging to main:**
- [x] All tests passing
- [x] PR reviewed and approved
- [x] Branch is up to date with main
- [x] No merge conflicts

## Related issues
<!-- Link any related issues: Fixes #123 -->
