### PR TITLE
chore: bake APP_VERSION into Docker image at build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,16 +26,6 @@ jobs:
         id: version
         run: echo "VERSION=$(jq -r '.version' frontend/package.json)" >> $GITHUB_OUTPUT
 
-      - name: Update docker-compose.yml with version
-        run: |
-          VERSION=$(jq -r '.version' frontend/package.json)
-          sed -i "s/APP_VERSION=.*/APP_VERSION=$VERSION/" docker-compose.yml
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add docker-compose.yml
-          git commit -m "chore: sync APP_VERSION to $VERSION" || true
-          git push origin HEAD:main || true
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -51,6 +41,8 @@ jobs:
           context: .
           file: Dockerfile.backend
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.VERSION }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/citynet-backend:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/citynet-backend:${{ steps.version.outputs.VERSION }}

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -4,5 +4,7 @@ WORKDIR /app
 COPY backend/package*.json ./
 RUN npm ci --omit=dev
 COPY backend/ .
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
 EXPOSE 5000
 CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - ./backend/.env
     environment:
       - DB_PATH=/app/data/city.db
-      - APP_VERSION=1.1.9
     volumes:
       - ./backend/data:/app/data
       - ./backend/uploads:/app/uploads


### PR DESCRIPTION
- Dockerfile.backend: ARG/ENV APP_VERSION baked in during CI build
- release.yml: pass --build-arg APP_VERSION from package.json; remove the fragile auto-sync-to-docker-compose step entirely
- docker-compose.yml: remove APP_VERSION env var (no longer needed)

Users now get the correct version automatically when they pull the image — no local file stays out of sync.

## Summary
<!-- Describe what changed and why -->

## Test plan
<!-- How should this be tested? -->
- [ ] Tested locally
- [ ] Tests pass

## Pre-merge checklist

**Code quality:**
- [ ] Code follows project style
- [ ] No breaking changes (or clearly documented)
- [ ] No console errors or warnings

**Version & Release:**
- [ ] **Version bumped?** If releasing to users, update:
  - [ ] `frontend/package.json` version
  - [ ] `docker-compose.yml` `APP_VERSION`
  - [ ] `CHANGELOG.md` with release notes
- [ ] GitHub Actions will auto-tag Docker images with the new version

**Before merging to main:**
- [ ] All tests passing
- [ ] PR reviewed and approved
- [ ] Branch is up to date with main
- [ ] No merge conflicts

## Related issues
<!-- Link any related issues: Fixes #123 -->
