### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.2] - 2026-07-06
+
+### Fixed
+- **In-app update** — backend now runs as root to access Docker socket; compose project name detected from container labels so correct containers are replaced
+
+---
+
 ## [1.2.1] - 2026-07-06
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
Tests in-app update with docker socket fix (user: root) and compose project name detection.
