### PR TITLE
fix: read container ID from /etc/hostname not os.hostname()

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -263,14 +263,14 @@ module.exports = (db, io, { emitUpdate, recordAction }) => {
     if (req.user.isTemporary) return res.status(403).json({ error: 'Primary admin only' });
 
     const { spawn, execSync } = require('child_process');
-    const os = require('os');
+    const fs = require('fs');
 
     res.json({ message: 'Update started' });
 
     // Read this container's compose project name from its own Docker labels
     let projectArgs = [];
     try {
-      const containerId = os.hostname();
+      const containerId = fs.readFileSync('/etc/hostname', 'utf8').trim();
       const label = execSync(
         `docker inspect ${containerId} --format '{{index .Config.Labels "com.docker.compose.project"}}'`,
         { encoding: 'utf8' }


### PR DESCRIPTION
os.hostname() was returning the Windows host name instead of the container ID, breaking the compose project name lookup.

## Summary
<!-- Describe what changed and why -->

## Test plan
<!-- How should this be tested? -->
- [ ] Tested locally
- [ ] Tests pass

## Pre-merge checklist

**Code quality:**
- [ ] Code follows project style
- [ ] No breaking changes (or clearly documented)
- [ ] No console errors or warnings

**Version & Release:**
- [ ] **Version bumped?** If releasing to users, update:
  - [ ] `frontend/package.json` version
  - [ ] `docker-compose.yml` `APP_VERSION`
  - [ ] `CHANGELOG.md` with release notes
- [ ] GitHub Actions will auto-tag Docker images with the new version

**Before merging to main:**
- [ ] All tests passing
- [ ] PR reviewed and approved
- [ ] Branch is up to date with main
- [ ] No merge conflicts

## Related issues
<!-- Link any related issues: Fixes #123 -->
