### PR TITLE
fix: read app version from package.json when APP_VERSION env not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.4.1] - 2026-07-14
+
+### Fixed
+- **App version fallback** — backend `/api/check-update` now reads the running version from `package.json` when the `APP_VERSION` env var is not set (manual installs and dev environments no longer show a false "update available" prompt)
+
+---
+
 ## [1.4.0] - 2026-07-13
 
 Cyberpunk RED character sheets: the full Phase 3-5 sheet system, making CP:R the first feature-complete game system.

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -216,7 +216,7 @@ module.exports = (db, io, { emitUpdate, recordAction }) => {
     if (req.user.isTemporary) return res.status(403).json({ error: 'Primary admin only' });
 
     const https = require('https');
-    const currentVersion = process.env.APP_VERSION || '1.1.8';
+    const currentVersion = process.env.APP_VERSION || require('../../package.json').version;
 
     const options = {
       hostname: 'hub.docker.com',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapsystem",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why -->

## Test plan
<!-- How should this be tested? -->
- [ ] Tested locally
- [ ] Tests pass

## Pre-merge checklist

**Code quality:**
- [ ] Code follows project style
- [ ] No breaking changes (or clearly documented)
- [ ] No console errors or warnings

**Version & Release:**
- [ ] **Version bumped?** If releasing to users, update:
  - [ ] `frontend/package.json` version
  - [ ] `docker-compose.yml` `APP_VERSION`
  - [ ] `CHANGELOG.md` with release notes
- [ ] GitHub Actions will auto-tag Docker images with the new version

**Before merging to main:**
- [ ] All tests passing
- [ ] PR reviewed and approved
- [ ] Branch is up to date with main
- [ ] No merge conflicts

## Related issues
<!-- Link any related issues: Fixes #123 -->
