### PR TITLE
fix: extend npcSheetGenerated socket type and bump to 1.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,6 @@ jobs:
 
       - name: Run Tests
         run: npm test
+
+      - name: Build (type-check + bundle)
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.6.2] - 2026-07-19
+
+### Fixed
+
+- **Docker build** — extend `npcSheetGenerated` socket type in `useSocket.ts` to include `system`, `portrait_url`, `sheet_name`, and `sheet_description`; TypeScript was rejecting the fields added in 1.6.1 and failing the production build
+
+---
+
 ## [1.6.1] - 2026-07-19
 
 SR6 polish: drain resistance, glitch feedback, Edge management, NPC sheet fixes, and name/description sync.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -37,7 +37,7 @@ interface UseSocketOptions {
   onSpectatorCount?: (count: number) => void;
   onAttackPending?: (data: { targetId: number; targetName: string; attackType: 'melee' | 'ranged'; ac: number }) => void;
   onGameSystemChanged?: (system: string) => void;
-  onNpcSheetGenerated?: (data: { location_id: number; sheet_id: number; npc_label: string }) => void;
+  onNpcSheetGenerated?: (data: { location_id: number; sheet_id: number; npc_label: string; system?: string; portrait_url?: string | null; sheet_name?: string | null; sheet_description?: string | null }) => void;
   /** NPC sheet attached to / detached from a token (admin library ATTACH). */
   onNpcLinkChanged?: (data: { location_id: number; sheet_id: number | null }) => void;
   /** Fires whenever diceRollBroadcast is received for the local user — used to pop the dice tray from the standalone sheet tab. */
@@ -202,7 +202,7 @@ export function useSocket({
 
     newSocket.on('attackPending', (data: { targetId: number; targetName: string; attackType: 'melee' | 'ranged'; ac: number }) => onAttackPending?.(data));
     newSocket.on('gameSystemChanged', (data: { system: string }) => onGameSystemChanged?.(data.system));
-    newSocket.on('npcSheetGenerated', (data: { location_id: number; sheet_id: number; npc_label: string }) => onNpcSheetGenerated?.(data));
+    newSocket.on('npcSheetGenerated', (data: { location_id: number; sheet_id: number; npc_label: string; system?: string; portrait_url?: string | null; sheet_name?: string | null; sheet_description?: string | null }) => onNpcSheetGenerated?.(data));
     newSocket.on('npcLinkChanged', (data: { location_id: number; sheet_id: number | null }) => onNpcLinkChanged?.(data));
     newSocket.on('diceRollBroadcast', (data: { userName: string; account?: string }) => onDiceRollBroadcast?.(data));
     newSocket.on('sheetAttackError', (data: { message: string }) => onNotification(data.message));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapsystem",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
TypeScript build was rejecting system/portrait_url/sheet_name/sheet_description fields on the npcSheetGenerated payload added in 1.6.1, breaking the Docker release workflow.

## Summary
<!-- Describe what changed and why -->

## Test plan
<!-- How should this be tested? -->
- [ ] Tested locally
- [ ] Tests pass

## Pre-merge checklist

**Code quality:**
- [ ] Code follows project style
- [ ] No breaking changes (or clearly documented)
- [ ] No console errors or warnings

**Version & Release:**
- [ ] **Version bumped?** If releasing to users, update:
  - [ ] `frontend/package.json` version
  - [ ] `docker-compose.yml` `APP_VERSION`
  - [ ] `CHANGELOG.md` with release notes
- [ ] GitHub Actions will auto-tag Docker images with the new version

**Before merging to main:**
- [ ] All tests passing
- [ ] PR reviewed and approved
- [ ] Branch is up to date with main
- [ ] No merge conflicts

## Related issues
<!-- Link any related issues: Fixes #123 -->
