### PR TITLE
fix: mount host project dir at its own path in self-update helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   now explicitly excluded.
 - **DB path startup log** — the resolved database path is now printed on boot
   (`[db] opening database at: …`) for easier deployment debugging.
+- **In-app update wipes data** — the self-update route mounted the host project
+  directory at `/project` inside the helper container, so compose resolved
+  `./backend/data` to `/project/backend/data` and passed that to the host Docker
+  daemon. The daemon found no such path and created a new empty bind mount,
+  wiping all map data on every in-app update. Fixed by mounting at the host's
+  own absolute path so the daemon receives paths it can actually resolve.
 
 ### Added
 

--- a/backend/__tests__/update_helper.test.js
+++ b/backend/__tests__/update_helper.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { buildUpdateHelperArgs } from '../routes/admin.js';
+
+const WORKING_DIR = '/opt/mapsystem';
+const CONFIG_FILE = '/opt/mapsystem/docker-compose.yml';
+const NO_PROJECT = [];
+const WITH_PROJECT = ['-p', 'mapsystem'];
+
+describe('buildUpdateHelperArgs — volume mounts', () => {
+  it('mounts the host working dir at its own path, not an alias', () => {
+    const args = buildUpdateHelperArgs(WORKING_DIR, CONFIG_FILE, NO_PROJECT);
+    const vArgs = args.filter((_, i) => args[i - 1] === '-v');
+    // The working-dir volume must be identity-mapped: hostPath:hostPath
+    expect(vArgs).toContain(`${WORKING_DIR}:${WORKING_DIR}`);
+  });
+
+  it('does NOT mount the working dir at /project or any other alias', () => {
+    const args = buildUpdateHelperArgs(WORKING_DIR, CONFIG_FILE, NO_PROJECT);
+    // The exact working-dir volume entry must be identity-mapped; an alias
+    // like /opt/mapsystem:/project would pass to the daemon as /project,
+    // causing Docker to create a new empty directory and wipe existing data.
+    expect(args).not.toContain(`${WORKING_DIR}:/project`);
+    // More generally: no entry should mount the working dir at a different target
+    const vArgs = args.filter((_, i) => args[i - 1] === '-v');
+    const wrongMount = vArgs.find(v => v === `${WORKING_DIR}:${WORKING_DIR}`) === undefined
+      && vArgs.some(v => v.startsWith(`${WORKING_DIR}:`) && !v.startsWith(`${WORKING_DIR}:${WORKING_DIR}`));
+    expect(wrongMount).toBe(false);
+  });
+
+  it('passes --project-directory pointing to the host working dir', () => {
+    const args = buildUpdateHelperArgs(WORKING_DIR, CONFIG_FILE, NO_PROJECT);
+    const shellCmd = args[args.length - 1];
+    expect(shellCmd).toContain(`--project-directory "${WORKING_DIR}"`);
+    expect(shellCmd).not.toContain('--project-directory "/project"');
+    expect(shellCmd).not.toContain('--project-directory /project');
+  });
+
+  it('mounts the compose file read-only at /tmp/docker-compose.yml', () => {
+    const args = buildUpdateHelperArgs(WORKING_DIR, CONFIG_FILE, NO_PROJECT);
+    const vArgs = args.filter((_, i) => args[i - 1] === '-v');
+    expect(vArgs).toContain(`${CONFIG_FILE}:/tmp/docker-compose.yml:ro`);
+  });
+
+  it('includes the docker socket mount', () => {
+    const args = buildUpdateHelperArgs(WORKING_DIR, CONFIG_FILE, NO_PROJECT);
+    const vArgs = args.filter((_, i) => args[i - 1] === '-v');
+    expect(vArgs).toContain('/var/run/docker.sock:/var/run/docker.sock');
+  });
+
+  it('forwards project name args into the shell command', () => {
+    const args = buildUpdateHelperArgs(WORKING_DIR, CONFIG_FILE, WITH_PROJECT);
+    const shellCmd = args[args.length - 1];
+    expect(shellCmd).toContain('-p mapsystem');
+  });
+});

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -299,15 +299,19 @@ module.exports = (db, io, { emitUpdate, recordAction }) => {
       if (code !== 0) return;
       // Spawn a temporary helper container to run up -d so it survives
       // the backend container being replaced mid-execution.
-      // Mount the host project dir at /project so compose resolves relative
-      // paths (./backend/data etc.) correctly regardless of host OS.
+      // Mount the host project dir at its *own host path* (not /project) so
+      // that when compose resolves relative paths like ./backend/data, the
+      // resulting absolute path matches what the host Docker daemon sees.
+      // Using a different mountpoint (e.g. /project) caused the daemon to
+      // look for /project/backend/data on the host, which doesn't exist,
+      // creating a new empty bind mount and wiping data on every update.
       const helper = spawn('docker', [
         'run', '--rm',
         '-v', '/var/run/docker.sock:/var/run/docker.sock',
-        '-v', `${hostWorkingDir}:/project`,
+        '-v', `${hostWorkingDir}:${hostWorkingDir}`,
         '-v', `${hostConfigFile}:/tmp/docker-compose.yml:ro`,
         'over2take/citynet-backend:latest',
-        'sh', '-c', `docker compose --project-directory /project -f /tmp/docker-compose.yml ${projectArgs.join(' ')} up -d`,
+        'sh', '-c', `docker compose --project-directory "${hostWorkingDir}" -f /tmp/docker-compose.yml ${projectArgs.join(' ')} up -d`,
       ], { detached: true, stdio: 'ignore' });
       helper.unref();
     });

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -6,6 +6,28 @@ const { authenticate } = require('../middleware/auth');
 const SECRET = process.env.JWT_SECRET;
 let currentController = 'GM';
 
+/**
+ * Build the docker-run argument list for the self-update helper container.
+ *
+ * The host project directory MUST be mounted at its own absolute path, not at
+ * an alias like /project. Compose passes volume host-paths straight to the
+ * Docker daemon; if those paths don't exist on the host the daemon silently
+ * creates a new empty directory, wiping existing bind-mount data (issue that
+ * caused data loss on in-app updates prior to 1.6.3).
+ */
+function buildUpdateHelperArgs(hostWorkingDir, hostConfigFile, projectArgs) {
+  const projectArgsStr = projectArgs.join(' ');
+  return [
+    'run', '--rm',
+    '-v', '/var/run/docker.sock:/var/run/docker.sock',
+    '-v', `${hostWorkingDir}:${hostWorkingDir}`,
+    '-v', `${hostConfigFile}:/tmp/docker-compose.yml:ro`,
+    'over2take/citynet-backend:latest',
+    'sh', '-c',
+    `docker compose --project-directory "${hostWorkingDir}" -f /tmp/docker-compose.yml ${projectArgsStr} up -d`,
+  ];
+}
+
 module.exports = (db, io, { emitUpdate, recordAction }) => {
   const router = express.Router();
 
@@ -305,14 +327,7 @@ module.exports = (db, io, { emitUpdate, recordAction }) => {
       // Using a different mountpoint (e.g. /project) caused the daemon to
       // look for /project/backend/data on the host, which doesn't exist,
       // creating a new empty bind mount and wiping data on every update.
-      const helper = spawn('docker', [
-        'run', '--rm',
-        '-v', '/var/run/docker.sock:/var/run/docker.sock',
-        '-v', `${hostWorkingDir}:${hostWorkingDir}`,
-        '-v', `${hostConfigFile}:/tmp/docker-compose.yml:ro`,
-        'over2take/citynet-backend:latest',
-        'sh', '-c', `docker compose --project-directory "${hostWorkingDir}" -f /tmp/docker-compose.yml ${projectArgs.join(' ')} up -d`,
-      ], { detached: true, stdio: 'ignore' });
+      const helper = spawn('docker', buildUpdateHelperArgs(hostWorkingDir, hostConfigFile, projectArgs), { detached: true, stdio: 'ignore' });
       helper.unref();
     });
   });
@@ -332,3 +347,5 @@ module.exports = (db, io, { emitUpdate, recordAction }) => {
 
   return router;
 };
+
+module.exports.buildUpdateHelperArgs = buildUpdateHelperArgs;


### PR DESCRIPTION
The helper container was mounting hostWorkingDir at /project, so compose resolved ./backend/data to /project/backend/data and passed that to the host Docker daemon. The daemon found no such path on the host and created a new empty bind mount, wiping all map data on every in-app update.

Fix: mount as hostWorkingDir:hostWorkingDir so compose generates absolute paths the host daemon can actually resolve.

## Summary
<!-- Describe what changed and why -->

## Test plan
<!-- How should this be tested? -->
- [ ] Tested locally
- [ ] Tests pass

## Pre-merge checklist

**Code quality:**
- [ ] Code follows project style
- [ ] No breaking changes (or clearly documented)
- [ ] No console errors or warnings

**Version & Release:**
- [ ] **Version bumped?** If releasing to users, update:
  - [ ] `frontend/package.json` version
  - [ ] `docker-compose.yml` `APP_VERSION`
  - [ ] `CHANGELOG.md` with release notes
- [ ] GitHub Actions will auto-tag Docker images with the new version

**Before merging to main:**
- [ ] All tests passing
- [ ] PR reviewed and approved
- [ ] Branch is up to date with main
- [ ] No merge conflicts

## Related issues
<!-- Link any related issues: Fixes #123 -->
