### PR TITLE
fix: harden Secure Mode's account check at connect time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.11.4] - 2026-08-28
+
+Stronger Secure Mode.
+
+### Changed
+
+- **Secure Mode checks accounts more strictly when a connection joins.** The account check now runs against fully verified credentials rather than partly trusting what the connecting client says about itself, so it holds in cases where it previously could be sidestepped. Recommended for anyone running with Secure Mode on. Nothing changes day to day: admins, approved players and temporary admin access all work exactly as before, and servers running with Secure Mode off are unaffected.
+
+---
+
 ## [1.11.3] - 2026-08-28
 
 Security patch for the realtime connection.

--- a/backend/__tests__/sockets.identify.secure.test.js
+++ b/backend/__tests__/sockets.identify.secure.test.js
@@ -1,0 +1,168 @@
+/**
+ * Secure Mode's gate on the `identify` handler in sockets/index.js.
+ *
+ * `isAdmin` arrives as a plain field in the client's payload, so it is a claim until a
+ * token backs it. The Secure Mode check used to run before the claim was resolved and
+ * skipped itself whenever the claim was present, so `{ isAdmin: true }` with no token at
+ * all walked past the player-token requirement and connected as an ordinary player. No
+ * admin rights were granted, which was never the hole; the hole was getting onto a server
+ * that is supposed to admit nobody without an approved account.
+ *
+ * These drive the real module rather than a copy of the handler, so a regression in
+ * sockets/index.js actually fails them.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+import { makeTestDb, run } from './helpers/testDb.js';
+
+process.env.JWT_SECRET = 'test-secret';
+const SECRET = 'test-secret';
+
+const socketsFactory = (await import('../sockets/index.js')).default;
+
+const flush = (ms = 25) => new Promise((r) => setTimeout(r, ms));
+
+const ADMIN_TOKEN = jwt.sign({ username: 'admin', isTemporary: false }, SECRET);
+const TEMP_ADMIN_TOKEN = jwt.sign({ username: 'helper', isTemporary: true }, SECRET);
+const PLAYER_TOKEN = jwt.sign({ username: 'realplayer', role: 'player' }, SECRET);
+const HELPER_PLAYER_TOKEN = jwt.sign({ username: 'helper', role: 'player' }, SECRET);
+
+function boot(db) {
+  const emitted = [];
+  let connectionCb;
+  const io = {
+    on: (event, cb) => { if (event === 'connection') connectionCb = cb; },
+    emit: (event, data) => emitted.push({ event, data }),
+    to: () => ({ emit: (event, data) => emitted.push({ event, data }) }),
+  };
+  socketsFactory(io, db, { elevatedUsers: new Set(), emitUpdate: vi.fn(), recordAction: vi.fn() });
+
+  const handlers = {};
+  const disconnect = vi.fn();
+  const socket = {
+    id: `sock-${Math.random().toString(36).slice(2)}`,
+    on: (event, fn) => { handlers[event] = fn; },
+    emit: (event, data) => emitted.push({ event, data, direct: true }),
+    use: () => {},
+    join: () => {},
+    disconnect,
+  };
+  connectionCb(socket);
+  return { handlers, emitted, disconnect };
+}
+
+/** Run one identify payload and report how the server treated it. */
+async function identify(db, payload) {
+  const { handlers, emitted, disconnect } = boot(db);
+  handlers.identify(payload);
+  await flush();
+  const authError = emitted.find((e) => e.event === 'authError');
+  const roster = emitted.filter((e) => e.event === 'activeUsersUpdated').pop();
+  const me = roster && roster.data.find((u) => u.userName === payload.userName);
+  return {
+    rejected: Boolean(authError) && disconnect.mock.calls.length > 0,
+    reason: authError && authError.data.message,
+    admitted: Boolean(me),
+    isAdmin: me ? me.isAdmin : null,
+  };
+}
+
+let db;
+beforeEach(async () => {
+  db = await makeTestDb();
+  await run(db, `INSERT INTO global_settings (key, value) VALUES ('game_system', 'cyberpunk_red')`);
+});
+afterEach(() => { delete process.env.SECURE_MODE; });
+
+describe('Secure Mode gate on identify', () => {
+  beforeEach(() => { process.env.SECURE_MODE = 'true'; });
+
+  it('turns away a connection with no player token', async () => {
+    const r = await identify(db, { userName: 'nobody', isAdmin: false });
+    expect(r.rejected).toBe(true);
+    expect(r.reason).toMatch(/player token required/i);
+    expect(r.admitted).toBe(false);
+  });
+
+  it('turns away a bare isAdmin claim carrying no token', async () => {
+    // The regression. Claiming admin used to skip the check above entirely, landing the
+    // caller in the room as a plain player without an approved account.
+    const r = await identify(db, { userName: 'intruder', isAdmin: true });
+    expect(r.rejected).toBe(true);
+    expect(r.reason).toMatch(/player token required/i);
+    expect(r.admitted).toBe(false);
+  });
+
+  it('turns away an isAdmin claim carrying a junk token', async () => {
+    const r = await identify(db, { userName: 'intruder', isAdmin: true, token: 'not-a-jwt' });
+    expect(r.rejected).toBe(true);
+    expect(r.admitted).toBe(false);
+  });
+
+  it('turns away a player token issued to someone else', async () => {
+    const r = await identify(db, { userName: 'impostor', isAdmin: false, playerToken: PLAYER_TOKEN });
+    expect(r.rejected).toBe(true);
+    expect(r.reason).toMatch(/invalid or expired/i);
+    expect(r.admitted).toBe(false);
+  });
+
+  it('lets a real admin in, and does not ask them for a player token', async () => {
+    const r = await identify(db, { userName: 'admin', isAdmin: true, token: ADMIN_TOKEN });
+    expect(r.rejected).toBe(false);
+    expect(r.admitted).toBe(true);
+    expect(r.isAdmin).toBe(true);
+  });
+
+  it('lets an approved player in on their own token', async () => {
+    const r = await identify(db, { userName: 'realplayer', isAdmin: false, playerToken: PLAYER_TOKEN });
+    expect(r.rejected).toBe(false);
+    expect(r.admitted).toBe(true);
+    expect(r.isAdmin).toBe(false);
+  });
+
+  it('holds a temporary admin to the player-token requirement', async () => {
+    // A temporary token resolves isAdmin to false, so the gate must then apply to them
+    // like any other player rather than waving them through on the original claim.
+    const r = await identify(db, { userName: 'helper', isAdmin: true, token: TEMP_ADMIN_TOKEN });
+    expect(r.rejected).toBe(true);
+    expect(r.admitted).toBe(false);
+  });
+
+  it('lets a granted temporary admin back in on their own player token', async () => {
+    // The real shape of the temporary-admin flow: an approved player is handed elevated
+    // access, and on the next reconnect the client sends the temporary token in `token`
+    // with their player token still alongside it. That has to keep working, or granting
+    // someone edit rights would lock them out the moment their connection blinked.
+    const r = await identify(db, {
+      userName: 'helper', isAdmin: true, token: TEMP_ADMIN_TOKEN, playerToken: HELPER_PLAYER_TOKEN,
+    });
+    expect(r.rejected).toBe(false);
+    expect(r.admitted).toBe(true);
+    expect(r.isAdmin).toBe(false); // elevation lives in elevatedUsers, not this flag
+  });
+});
+
+describe('open play is unaffected', () => {
+  beforeEach(() => { process.env.SECURE_MODE = 'false'; });
+
+  it('admits a player with no token at all', async () => {
+    const r = await identify(db, { userName: 'walkin', isAdmin: false });
+    expect(r.rejected).toBe(false);
+    expect(r.admitted).toBe(true);
+    expect(r.isAdmin).toBe(false);
+  });
+
+  it('admits a bare isAdmin claim but grants it nothing', async () => {
+    const r = await identify(db, { userName: 'chancer', isAdmin: true });
+    expect(r.rejected).toBe(false);
+    expect(r.admitted).toBe(true);
+    expect(r.isAdmin).toBe(false);
+  });
+
+  it('still recognises a real admin', async () => {
+    const r = await identify(db, { userName: 'admin', isAdmin: true, token: ADMIN_TOKEN });
+    expect(r.admitted).toBe(true);
+    expect(r.isAdmin).toBe(true);
+  });
+});

--- a/backend/sockets/index.js
+++ b/backend/sockets/index.js
@@ -170,6 +170,29 @@ module.exports = (io, db, { elevatedUsers, emitUpdate, recordAction }) => {
         return;
       }
 
+      // Settle whether this really is an admin before anything reads the flag.
+      //
+      // `isAdmin` arrives as a plain field in the client's payload, so on its own it is
+      // a claim and nothing more. This block used to sit *below* the Secure Mode check,
+      // which meant the check was branching on the unverified claim: sending
+      // `{ isAdmin: true }` with no token skipped the player-token requirement entirely,
+      // and only afterwards was the claim resolved to false. The result was a connection
+      // with no admin rights, which is correct, on a server that was supposed to admit
+      // nobody without an approved account, which is not. Resolving first means the
+      // Secure Mode check below reads a verified value.
+      if (info.isAdmin && info.token) {
+        try {
+          const verified = jwt.verify(info.token, SECRET);
+          if (verified.isTemporary) info.isAdmin = false;
+        } catch (err) {
+          console.warn(`User ${info.userName} claimed admin but provided invalid token.`);
+          info.isAdmin = false;
+        }
+      } else {
+        info.isAdmin = false;
+      }
+      delete info.token;
+
       // Secure Mode: verify player token before allowing connection
       if (process.env.SECURE_MODE === 'true' && !info.isAdmin) {
         if (!info.playerToken) {
@@ -187,19 +210,6 @@ module.exports = (io, db, { elevatedUsers, emitUpdate, recordAction }) => {
         }
       }
       delete info.playerToken;
-
-      if (info.isAdmin && info.token) {
-        try {
-          const verified = jwt.verify(info.token, SECRET);
-          if (verified.isTemporary) info.isAdmin = false;
-        } catch (err) {
-          console.warn(`User ${info.userName} claimed admin but provided invalid token.`);
-          info.isAdmin = false;
-        }
-      } else {
-        info.isAdmin = false;
-      }
-      delete info.token;
 
       console.log(`User identified: ${info.userName} (Admin: ${info.isAdmin})`);
       userSockets.set(socket.id, info);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.11.3",
+  "version": "1.11.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapsystem",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The check ran before the connecting client's admin flag had been resolved against its token, so it was partly branching on an unverified value and could be sidestepped. Resolving the flag first and gating on the result closes that: the two blocks swap order, with no new logic.

A temporary admin token resolves the flag to false and is now held to the same account requirement, which is the intended behaviour - the client sends the player token alongside the temporary one, so a granted user reconnects normally.

Verified against a real container: an approved player joins, an admin grants them temporary access, and they survive a reconnect. Real admin tokens, approved player tokens, and servers with Secure Mode off are all unchanged.

Eleven regression tests drive the real socket module rather than a copy of the handler; three of them fail against the previous ordering.

## Summary
<!-- Describe what changed and why -->

## Test plan
<!-- How should this be tested? -->
- [ ] Tested locally
- [ ] Tests pass

## Pre-merge checklist

**Code quality:**
- [ ] Code follows project style
- [ ] No breaking changes (or clearly documented)
- [ ] No console errors or warnings

**Version & Release:**
- [ ] **Version bumped?** If releasing to users, update:
  - [ ] `frontend/package.json` version
  - [ ] `docker-compose.yml` `APP_VERSION`
  - [ ] `CHANGELOG.md` with release notes
- [ ] GitHub Actions will auto-tag Docker images with the new version

**Before merging to main:**
- [ ] All tests passing
- [ ] PR reviewed and approved
- [ ] Branch is up to date with main
- [ ] No merge conflicts

## Related issues
<!-- Link any related issues: Fixes #123 -->
